### PR TITLE
Phase 6: MCP server implementation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -603,7 +603,7 @@ Logic: Try API key first (check prefix), fall back to OAuth token validation.
 - 1 API key
 - 500 MCP requests/day
 
-**Paid Plan — $20/month ($16/month billed annually):**
+**Paid Plan — $10/month ($8/month billed annually):**
 - Everything in Free
 - Full MCP write access (create, update, delete, rollover, reorder)
 - All MCP prompt templates (daily planning, weekly review, habit analysis, etc.)
@@ -611,7 +611,7 @@ Logic: Try API key first (check prefix), fall back to OAuth token validation.
 - Unlimited API keys
 - 10,000 MCP requests/day
 - Data export (JSON/CSV)
-**Annual plan: $192/year ($16/month):**
+**Annual plan: $96/year ($8/month):**
 - 2 months free vs monthly
 
 **Why this works:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "personal-ai-chatbot",
       "version": "0.1.0",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@openrouter/sdk": "^0.3.14",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.90.1",
@@ -19,7 +20,8 @@
         "react-markdown": "^10.1.0",
         "recharts": "^3.8.0",
         "remark-gfm": "^4.0.1",
-        "resend": "^6.9.4"
+        "resend": "^6.9.4",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -1197,6 +1199,18 @@
         }
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1764,6 +1778,68 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -3820,6 +3896,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3869,6 +3958,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -4176,6 +4304,30 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -4234,6 +4386,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -4257,7 +4418,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4271,7 +4431,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4443,6 +4602,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -4463,11 +4644,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4813,6 +5019,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -4870,7 +5085,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4880,6 +5094,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
@@ -4894,6 +5114,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
@@ -4995,7 +5224,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5005,7 +5233,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5050,7 +5277,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5167,6 +5393,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -5625,11 +5857,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -5639,6 +5901,76 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/extend": {
@@ -5651,7 +5983,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -5704,6 +6035,22 @@
       "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
       "license": "Unlicense"
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5738,6 +6085,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -5794,6 +6162,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5813,7 +6199,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5874,7 +6259,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5899,7 +6283,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -5987,7 +6370,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6059,7 +6441,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6088,7 +6469,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6154,6 +6534,15 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -6175,6 +6564,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -6212,6 +6621,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -6271,6 +6696,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -6299,6 +6730,24 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-alphabetical": {
@@ -6634,6 +7083,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -6790,7 +7245,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -6819,6 +7273,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -6908,6 +7371,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -7350,7 +7819,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7644,6 +8112,27 @@
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -8232,6 +8721,31 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -8311,6 +8825,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "16.2.1",
@@ -8404,7 +8927,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8414,7 +8936,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8533,6 +9054,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/openai": {
       "version": "6.16.0",
@@ -8674,6 +9216,15 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -8688,7 +9239,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8700,6 +9250,16 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -8725,6 +9285,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8842,6 +9411,19 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -8850,6 +9432,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -8872,6 +9469,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "19.2.3",
@@ -9133,7 +9754,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9263,6 +9883,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9342,6 +9978,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -9369,6 +10011,51 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/set-function-length": {
@@ -9419,6 +10106,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -9482,7 +10175,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9495,7 +10187,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9505,7 +10196,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9525,7 +10215,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9542,7 +10231,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9561,7 +10249,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9625,6 +10312,15 @@
       "dependencies": {
         "@stablelib/base64": "^1.0.0",
         "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/std-env": {
@@ -10030,6 +10726,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
@@ -10132,6 +10837,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -10372,6 +11091,15 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -10468,6 +11196,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vfile": {
@@ -10769,7 +11506,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10897,6 +11633,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -10956,12 +11698,21 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
-      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zod-validation-error": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@openrouter/sdk": "^0.3.14",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.90.1",
@@ -23,7 +24,8 @@
     "react-markdown": "^10.1.0",
     "recharts": "^3.8.0",
     "remark-gfm": "^4.0.1",
-    "resend": "^6.9.4"
+    "resend": "^6.9.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/admin/limits/__tests__/route.test.ts
+++ b/src/app/api/admin/limits/__tests__/route.test.ts
@@ -105,7 +105,7 @@ describe("POST /api/admin/limits", () => {
     const res = await POST(
       makeRequest("/api/admin/limits", {
         method: "POST",
-        body: JSON.stringify({ limit_type: "cost", period: "invalid", limit_value: 10 }),
+        body: JSON.stringify({ limit_type: "requests", period: "invalid", limit_value: 10 }),
       })
     );
     expect(res.status).toBe(400);
@@ -118,7 +118,7 @@ describe("POST /api/admin/limits", () => {
     const res = await POST(
       makeRequest("/api/admin/limits", {
         method: "POST",
-        body: JSON.stringify({ limit_type: "cost", period: "daily", mode: "invalid", limit_value: 10 }),
+        body: JSON.stringify({ limit_type: "requests", period: "daily", mode: "invalid", limit_value: 10 }),
       })
     );
     expect(res.status).toBe(400);
@@ -130,7 +130,7 @@ describe("POST /api/admin/limits", () => {
     const res = await POST(
       makeRequest("/api/admin/limits", {
         method: "POST",
-        body: JSON.stringify({ limit_type: "cost", period: "daily", limit_value: 0 }),
+        body: JSON.stringify({ limit_type: "requests", period: "daily", limit_value: 0 }),
       })
     );
     expect(res.status).toBe(400);
@@ -140,7 +140,7 @@ describe("POST /api/admin/limits", () => {
   it("creates limit with valid input", async () => {
     const client = mockAdmin(true);
     // Override to return created data
-    const mockData = { id: "l1", limit_type: "cost", period: "daily", limit_value: 50 };
+    const mockData = { id: "l1", limit_type: "requests", period: "daily", limit_value: 50 };
     client.from.mockImplementation(() => {
       const builder = {
         select: vi.fn().mockReturnThis(),
@@ -160,7 +160,7 @@ describe("POST /api/admin/limits", () => {
     const res = await POST(
       makeRequest("/api/admin/limits", {
         method: "POST",
-        body: JSON.stringify({ limit_type: "cost", period: "daily", limit_value: 50 }),
+        body: JSON.stringify({ limit_type: "requests", period: "daily", limit_value: 50 }),
       })
     );
     expect(res.status).toBe(200);

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest } from "next/server";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { createMcpServer } from "@/lib/mcp/server";
+import { authenticateMcpRequest } from "@/lib/mcp/auth";
+import { checkMcpRateLimit } from "@/lib/mcp/rate-limit";
+
+/**
+ * MCP Server endpoint — handles all MCP communication via Streamable HTTP.
+ * Auth: Bearer token (OAuth via Hydra or API key with da_sk_ prefix).
+ * Stateless: each request is independently authenticated.
+ */
+
+async function handleMcpRequest(request: NextRequest): Promise<Response> {
+  // Authenticate
+  const authHeader = request.headers.get("Authorization");
+  const authResult = await authenticateMcpRequest(authHeader);
+
+  if (!authResult.ok) {
+    return new Response(JSON.stringify(authResult.error.body), {
+      status: authResult.error.status,
+      headers: {
+        "Content-Type": "application/json",
+        ...authResult.error.headers,
+      },
+    });
+  }
+
+  const { auth, plan } = authResult.result;
+
+  // Rate limit
+  const retryAfter = checkMcpRateLimit(auth.userId, plan);
+  if (retryAfter !== null) {
+    return new Response(
+      JSON.stringify({ error: "Rate limit exceeded" }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": String(retryAfter),
+        },
+      }
+    );
+  }
+
+  // Create stateless transport and server per request
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // stateless
+    enableJsonResponse: true,
+  });
+
+  const server = createMcpServer();
+
+  await server.connect(transport);
+
+  // Pass auth info so tool/resource handlers can access userId and scopes
+  const response = await transport.handleRequest(request, {
+    authInfo: {
+      token: authHeader?.replace(/^Bearer\s+/i, "") ?? "",
+      clientId: auth.clientId ?? "",
+      scopes: auth.scopes,
+      extra: {
+        userId: auth.userId,
+        plan,
+        authMethod: auth.authMethod,
+      },
+    },
+  });
+
+  // Clean up after response is sent
+  // Use waitUntil-like pattern: close after response streams
+  response.clone().body?.pipeTo(new WritableStream()).finally(() => {
+    server.close().catch(() => {});
+  });
+
+  return response;
+}
+
+export async function POST(request: NextRequest) {
+  return handleMcpRequest(request);
+}
+
+export async function GET(request: NextRequest) {
+  return handleMcpRequest(request);
+}
+
+export async function DELETE(request: NextRequest) {
+  return handleMcpRequest(request);
+}

--- a/src/lib/mcp/__tests__/auth.test.ts
+++ b/src/lib/mcp/__tests__/auth.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AuthResult } from "@/lib/token-validation";
+import { UserPlan } from "@/lib/mcp/types";
+
+// Mock token-validation before importing the module under test
+vi.mock("@/lib/token-validation", () => ({
+  validateMcpAuth: vi.fn(),
+}));
+
+// Mock the MCP supabase service client
+vi.mock("@/lib/mcp/supabase", () => ({
+  getServiceClient: vi.fn(),
+}));
+
+import { authenticateMcpRequest } from "@/lib/mcp/auth";
+import { validateMcpAuth } from "@/lib/token-validation";
+import { getServiceClient } from "@/lib/mcp/supabase";
+
+const mockValidateMcpAuth = vi.mocked(validateMcpAuth);
+const mockGetServiceClient = vi.mocked(getServiceClient);
+
+/** Build a minimal mock SupabaseClient that returns the given profile row. */
+function makeMockSupabase(profile: { plan: string } | null) {
+  const single = vi.fn().mockResolvedValue({ data: profile, error: null });
+  const eq = vi.fn().mockReturnValue({ single });
+  const select = vi.fn().mockReturnValue({ eq });
+  const from = vi.fn().mockReturnValue({ select });
+  return { from } as unknown as ReturnType<typeof getServiceClient>;
+}
+
+const validAuth: AuthResult = {
+  userId: "user-123",
+  authMethod: "api_key",
+  scopes: ["tasks:read", "tasks:write"],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("authenticateMcpRequest", () => {
+  it("returns 401 error when Authorization header is null", async () => {
+    mockValidateMcpAuth.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        error: "Missing Authorization header",
+        status: 401,
+        wwwAuthenticate: 'Bearer realm="dailyagent"',
+      },
+    });
+
+    const result = await authenticateMcpRequest(null);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.status).toBe(401);
+      expect(result.error.body.error).toContain("Missing");
+      expect(result.error.headers?.["WWW-Authenticate"]).toBeTruthy();
+    }
+  });
+
+  it("forwards the error from validateMcpAuth when token is invalid", async () => {
+    mockValidateMcpAuth.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        error: "Token is expired or revoked",
+        status: 401,
+        wwwAuthenticate: 'Bearer realm="dailyagent", error="invalid_token"',
+      },
+    });
+
+    const result = await authenticateMcpRequest("Bearer expired-token");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.status).toBe(401);
+      expect(result.error.body.error).toBe("Token is expired or revoked");
+      expect(result.error.headers?.["WWW-Authenticate"]).toContain("invalid_token");
+    }
+  });
+
+  it("returns auth + plan when token is valid and profile exists", async () => {
+    mockValidateMcpAuth.mockResolvedValueOnce({ ok: true, auth: validAuth });
+    mockGetServiceClient.mockReturnValue(makeMockSupabase({ plan: "active" }));
+
+    const result = await authenticateMcpRequest("Bearer valid-token");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.auth).toEqual(validAuth);
+      expect(result.result.plan).toBe("active" satisfies UserPlan);
+    }
+  });
+
+  it('defaults to "free" plan when profile is not found', async () => {
+    mockValidateMcpAuth.mockResolvedValueOnce({ ok: true, auth: validAuth });
+    mockGetServiceClient.mockReturnValue(makeMockSupabase(null));
+
+    const result = await authenticateMcpRequest("Bearer valid-token");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.result.plan).toBe("free" satisfies UserPlan);
+    }
+  });
+
+  it("does not include WWW-Authenticate header when error has no wwwAuthenticate field", async () => {
+    mockValidateMcpAuth.mockResolvedValueOnce({
+      ok: false,
+      error: {
+        error: "Token validation failed",
+        status: 500,
+      },
+    });
+
+    const result = await authenticateMcpRequest("Bearer broken-token");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.status).toBe(500);
+      // headers should be empty object when no wwwAuthenticate present
+      expect(result.error.headers?.["WWW-Authenticate"]).toBeUndefined();
+    }
+  });
+
+  it("passes the Authorization header through to validateMcpAuth", async () => {
+    mockValidateMcpAuth.mockResolvedValueOnce({ ok: true, auth: validAuth });
+    mockGetServiceClient.mockReturnValue(makeMockSupabase({ plan: "free" }));
+
+    await authenticateMcpRequest("Bearer my-token");
+
+    expect(mockValidateMcpAuth).toHaveBeenCalledWith("Bearer my-token");
+  });
+});

--- a/src/lib/mcp/__tests__/plan-gate.test.ts
+++ b/src/lib/mcp/__tests__/plan-gate.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { isPaidPlan, PAID_PLAN_REQUIRED } from "@/lib/mcp/plan-gate";
+import { UserPlan } from "@/lib/mcp/types";
+
+describe("isPaidPlan", () => {
+  it('returns true for "active" plan', () => {
+    expect(isPaidPlan("active")).toBe(true);
+  });
+
+  it('returns false for "free" plan', () => {
+    expect(isPaidPlan("free")).toBe(false);
+  });
+
+  it('returns false for "canceled" plan', () => {
+    expect(isPaidPlan("canceled")).toBe(false);
+  });
+
+  it('returns false for "expired" plan', () => {
+    expect(isPaidPlan("expired")).toBe(false);
+  });
+
+  it("only active plan is paid — all other UserPlan values return false", () => {
+    const plans: UserPlan[] = ["free", "canceled", "expired"];
+    for (const plan of plans) {
+      expect(isPaidPlan(plan)).toBe(false);
+    }
+  });
+});
+
+describe("PAID_PLAN_REQUIRED", () => {
+  it("is a non-empty string", () => {
+    expect(typeof PAID_PLAN_REQUIRED).toBe("string");
+    expect(PAID_PLAN_REQUIRED.length).toBeGreaterThan(0);
+  });
+
+  it("mentions upgrading or pricing", () => {
+    expect(PAID_PLAN_REQUIRED.toLowerCase()).toMatch(/upgrade|pricing|paid/);
+  });
+});

--- a/src/lib/mcp/__tests__/rate-limit.test.ts
+++ b/src/lib/mcp/__tests__/rate-limit.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { UserPlan } from "@/lib/mcp/types";
+
+describe("checkMcpRateLimit", () => {
+  let checkMcpRateLimit: typeof import("@/lib/mcp/rate-limit").checkMcpRateLimit;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    const mod = await import("@/lib/mcp/rate-limit");
+    checkMcpRateLimit = mod.checkMcpRateLimit;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns null for the first request (allowed)", () => {
+    expect(checkMcpRateLimit("user1", "free")).toBeNull();
+  });
+
+  it("returns null for requests under the free plan limit (500)", () => {
+    for (let i = 0; i < 499; i++) {
+      expect(checkMcpRateLimit("user-free", "free")).toBeNull();
+    }
+  });
+
+  it("blocks after 500 requests on the free plan", () => {
+    for (let i = 0; i < 500; i++) {
+      checkMcpRateLimit("user-free-block", "free");
+    }
+    const result = checkMcpRateLimit("user-free-block", "free");
+    expect(result).not.toBeNull();
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("returns null for requests under the active plan limit (10,000)", () => {
+    for (let i = 0; i < 9_999; i++) {
+      expect(checkMcpRateLimit("user-active", "active")).toBeNull();
+    }
+  });
+
+  it("blocks after 10,000 requests on the active plan", () => {
+    for (let i = 0; i < 10_000; i++) {
+      checkMcpRateLimit("user-active-block", "active");
+    }
+    const result = checkMcpRateLimit("user-active-block", "active");
+    expect(result).not.toBeNull();
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("returns a positive retryAfter number when blocked", () => {
+    for (let i = 0; i < 500; i++) {
+      checkMcpRateLimit("user-retry", "free");
+    }
+    const retryAfter = checkMcpRateLimit("user-retry", "free");
+    expect(typeof retryAfter).toBe("number");
+    expect(retryAfter).toBeGreaterThan(0);
+  });
+
+  it("old entries expire after 24 hours, allowing requests again", () => {
+    for (let i = 0; i < 500; i++) {
+      checkMcpRateLimit("user-expire", "free");
+    }
+    // Should be blocked now
+    expect(checkMcpRateLimit("user-expire", "free")).not.toBeNull();
+
+    // Advance past the 24-hour window
+    vi.advanceTimersByTime(86_400_001);
+
+    // Should be allowed again after expiry
+    expect(checkMcpRateLimit("user-expire", "free")).toBeNull();
+  });
+
+  it("canceled plan uses 500-request limit", () => {
+    for (let i = 0; i < 500; i++) {
+      checkMcpRateLimit("user-canceled", "canceled");
+    }
+    const result = checkMcpRateLimit("user-canceled", "canceled");
+    expect(result).not.toBeNull();
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("expired plan uses 500-request limit", () => {
+    for (let i = 0; i < 500; i++) {
+      checkMcpRateLimit("user-expired", "expired");
+    }
+    const result = checkMcpRateLimit("user-expired", "expired");
+    expect(result).not.toBeNull();
+    expect(result).toBeGreaterThan(0);
+  });
+
+  it("tracks different users independently", () => {
+    for (let i = 0; i < 500; i++) {
+      checkMcpRateLimit("user-a", "free");
+    }
+    // user-a is blocked
+    expect(checkMcpRateLimit("user-a", "free")).not.toBeNull();
+    // user-b is not affected
+    expect(checkMcpRateLimit("user-b", "free")).toBeNull();
+  });
+
+  it("retryAfter decreases as time advances", () => {
+    for (let i = 0; i < 500; i++) {
+      checkMcpRateLimit("user-time", "free");
+    }
+    const first = checkMcpRateLimit("user-time", "free") as number;
+    vi.advanceTimersByTime(3600_000); // advance 1 hour
+    const second = checkMcpRateLimit("user-time", "free") as number;
+    expect(second).toBeLessThan(first);
+  });
+});
+
+// Type check: UserPlan covers all plan strings used in tests
+const _planCheck: UserPlan = "free";
+void _planCheck;

--- a/src/lib/mcp/auth.ts
+++ b/src/lib/mcp/auth.ts
@@ -1,0 +1,57 @@
+import { validateMcpAuth, AuthResult } from "@/lib/token-validation";
+import { getServiceClient } from "./supabase";
+import { UserPlan } from "./types";
+
+export interface McpAuthResult {
+  auth: AuthResult;
+  plan: UserPlan;
+}
+
+export interface McpAuthError {
+  status: number;
+  body: Record<string, string>;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Authenticate an MCP request. Returns auth info + user plan,
+ * or an error with status code and headers.
+ */
+export async function authenticateMcpRequest(
+  authHeader: string | null
+): Promise<{ ok: true; result: McpAuthResult } | { ok: false; error: McpAuthError }> {
+  const validation = await validateMcpAuth(authHeader);
+
+  if (!validation.ok) {
+    const headers: Record<string, string> = {};
+    if (validation.error.wwwAuthenticate) {
+      headers["WWW-Authenticate"] = validation.error.wwwAuthenticate;
+    }
+    return {
+      ok: false,
+      error: {
+        status: validation.error.status,
+        body: { error: validation.error.error },
+        headers,
+      },
+    };
+  }
+
+  // Look up user plan
+  const supabase = getServiceClient();
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("plan")
+    .eq("id", validation.auth.userId)
+    .single();
+
+  const plan: UserPlan = (profile?.plan as UserPlan) || "free";
+
+  return {
+    ok: true,
+    result: {
+      auth: validation.auth,
+      plan,
+    },
+  };
+}

--- a/src/lib/mcp/plan-gate.ts
+++ b/src/lib/mcp/plan-gate.ts
@@ -1,0 +1,9 @@
+import { UserPlan } from "./types";
+
+/** Check if user has a paid/active plan */
+export function isPaidPlan(plan: UserPlan): boolean {
+  return plan === "active";
+}
+
+/** Error message for free users trying write operations */
+export const PAID_PLAN_REQUIRED = "This action requires a paid plan. Upgrade at https://dailyagent.dev/pricing";

--- a/src/lib/mcp/prompts/index.ts
+++ b/src/lib/mcp/prompts/index.ts
@@ -1,0 +1,880 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import { ServerRequest, ServerNotification } from "@modelcontextprotocol/sdk/types.js";
+
+type Extra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+// ---------------------------------------------------------------------------
+// Auth helper
+// ---------------------------------------------------------------------------
+
+function getUserId(extra: Extra): string | null {
+  const authInfo = (extra as unknown as { authInfo?: { extra?: Record<string, unknown> } }).authInfo;
+  return (authInfo?.extra?.userId as string) ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Data fetch helpers
+// ---------------------------------------------------------------------------
+
+async function fetchTodayTasks(userId: string) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data } = await supabase
+    .from("tasks")
+    .select("id, title, priority, done, task_date")
+    .eq("user_id", userId)
+    .or(`task_date.eq.${today},and(task_date.lt.${today},done.eq.false)`)
+    .order("priority", { ascending: true });
+
+  return data ?? [];
+}
+
+async function fetchActiveGoals(userId: string) {
+  const supabase = getServiceClient();
+
+  const { data } = await supabase
+    .from("goals")
+    .select("id, title, description, category, progress, target_date, status")
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .order("created_at", { ascending: false });
+
+  return data ?? [];
+}
+
+async function fetchTodayHabits(userId: string) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data: habits } = await supabase
+    .from("habits")
+    .select("id, name, description")
+    .eq("user_id", userId)
+    .eq("archived", false);
+
+  if (!habits) return [];
+
+  const { data: logs } = await supabase
+    .from("habit_logs")
+    .select("habit_id")
+    .in("habit_id", habits.map((h) => h.id))
+    .eq("log_date", today);
+
+  const completedIds = new Set((logs ?? []).map((l) => l.habit_id));
+
+  return habits.map((h) => ({ ...h, completed_today: completedIds.has(h.id) }));
+}
+
+async function fetchAllHabitsWithStats(userId: string) {
+  const supabase = getServiceClient();
+
+  const { data: habits } = await supabase
+    .from("habits")
+    .select("id, name, description, frequency")
+    .eq("user_id", userId)
+    .eq("archived", false);
+
+  if (!habits) return [];
+
+  const thirtyDaysAgo = new Date();
+  thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+  const fromDate = thirtyDaysAgo.toISOString().split("T")[0];
+
+  const { data: logs } = await supabase
+    .from("habit_logs")
+    .select("habit_id, log_date")
+    .in("habit_id", habits.map((h) => h.id))
+    .gte("log_date", fromDate);
+
+  const logsByHabit: Record<string, number> = {};
+  for (const log of logs ?? []) {
+    logsByHabit[log.habit_id] = (logsByHabit[log.habit_id] ?? 0) + 1;
+  }
+
+  return habits.map((h) => ({
+    ...h,
+    completionsLast30Days: logsByHabit[h.id] ?? 0,
+    completionRate: Math.round(((logsByHabit[h.id] ?? 0) / 30) * 100),
+  }));
+}
+
+async function fetchTodayFocusStats(userId: string) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data } = await supabase
+    .from("focus_sessions")
+    .select("id, duration_minutes, completed_at")
+    .eq("user_id", userId)
+    .gte("started_at", `${today}T00:00:00.000Z`)
+    .lte("started_at", `${today}T23:59:59.999Z`);
+
+  const sessions = data ?? [];
+  const completed = sessions.filter((s) => s.completed_at != null);
+  const totalMinutes = completed.reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+
+  return { totalSessions: sessions.length, completedSessions: completed.length, totalFocusMinutes: totalMinutes };
+}
+
+async function fetchRecentJournal(userId: string, limit = 7) {
+  const supabase = getServiceClient();
+
+  const { data } = await supabase
+    .from("journal_entries")
+    .select("id, entry_date, content, mood")
+    .eq("user_id", userId)
+    .order("entry_date", { ascending: false })
+    .limit(limit);
+
+  return data ?? [];
+}
+
+async function fetchRecentWorkouts(userId: string, limit = 5) {
+  const supabase = getServiceClient();
+
+  const { data } = await supabase
+    .from("workout_logs")
+    .select("id, name, log_date, duration_minutes")
+    .eq("user_id", userId)
+    .order("log_date", { ascending: false })
+    .limit(limit);
+
+  return data ?? [];
+}
+
+async function fetchWorkoutTemplates(userId: string) {
+  const supabase = getServiceClient();
+
+  const { data } = await supabase
+    .from("workout_templates")
+    .select("id, name, workout_exercises(name)")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  return data ?? [];
+}
+
+async function fetchGoalById(userId: string, goalId: string) {
+  const supabase = getServiceClient();
+
+  const { data } = await supabase
+    .from("goals")
+    .select("*")
+    .eq("id", goalId)
+    .eq("user_id", userId)
+    .single();
+
+  return data ?? null;
+}
+
+async function fetchSpaceTasks(userId: string, spaceId?: string) {
+  const supabase = getServiceClient();
+
+  let query = supabase
+    .from("tasks")
+    .select("id, title, priority, done, task_date, space_id")
+    .eq("user_id", userId)
+    .eq("done", false)
+    .order("priority", { ascending: true });
+
+  if (spaceId) query = query.eq("space_id", spaceId);
+
+  const { data } = await query.limit(50);
+  return data ?? [];
+}
+
+async function fetchFocusSessionsForRange(userId: string, from: string, to: string) {
+  const supabase = getServiceClient();
+
+  const { data } = await supabase
+    .from("focus_sessions")
+    .select("id, duration_minutes, completed_at, started_at")
+    .eq("user_id", userId)
+    .gte("started_at", `${from}T00:00:00.000Z`)
+    .lte("started_at", `${to}T23:59:59.999Z`);
+
+  return data ?? [];
+}
+
+async function fetchTasksForRange(userId: string, from: string, to: string) {
+  const supabase = getServiceClient();
+
+  const { data } = await supabase
+    .from("tasks")
+    .select("id, title, priority, done, task_date")
+    .eq("user_id", userId)
+    .gte("task_date", from)
+    .lte("task_date", to);
+
+  return data ?? [];
+}
+
+async function fetchHabitLogsForRange(userId: string, from: string, to: string) {
+  const supabase = getServiceClient();
+
+  const { data: habits } = await supabase
+    .from("habits")
+    .select("id, name")
+    .eq("user_id", userId)
+    .eq("archived", false);
+
+  if (!habits || habits.length === 0) return { habits: [], logs: [] };
+
+  const { data: logs } = await supabase
+    .from("habit_logs")
+    .select("habit_id, log_date")
+    .in("habit_id", habits.map((h) => h.id))
+    .gte("log_date", from)
+    .lte("log_date", to);
+
+  return { habits, logs: logs ?? [] };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerPrompts(server: McpServer) {
+  // 1. daily_planning
+  server.prompt(
+    "daily_planning",
+    "Plan my day based on tasks, habits, and calendar",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const [tasks, habits, goals] = await Promise.all([
+        fetchTodayTasks(userId),
+        fetchTodayHabits(userId),
+        fetchActiveGoals(userId),
+      ]);
+
+      const today = new Date().toISOString().split("T")[0];
+
+      const systemText = `You are a productivity coach helping plan a focused, intentional day. Use the Franklin Covey A/B/C priority system to guide task ordering. A = must do today, B = should do, C = nice to have.`;
+
+      const userText = `Please help me plan my day for ${today}.
+
+## Today's Tasks
+${JSON.stringify(tasks, null, 2)}
+
+## Habits to Track Today
+${JSON.stringify(habits, null, 2)}
+
+## Active Goals
+${JSON.stringify(goals, null, 2)}
+
+Based on this data, please:
+1. Identify my top 3 priority tasks for today (A-priority or most impactful)
+2. Suggest a time-blocked schedule
+3. Highlight any habits I haven't completed yet
+4. Note which tasks align with my active goals
+5. Give me a motivating focus for the day`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: systemText } },
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 2. morning_briefing
+  server.prompt(
+    "morning_briefing",
+    "Quick morning snapshot of what's ahead today",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const [tasks, habits, goals] = await Promise.all([
+        fetchTodayTasks(userId),
+        fetchTodayHabits(userId),
+        fetchActiveGoals(userId),
+      ]);
+
+      const today = new Date().toISOString().split("T")[0];
+      const pendingTasks = tasks.filter((t) => !t.done);
+      const aCount = pendingTasks.filter((t) => t.priority === "A").length;
+
+      const userText = `Good morning! Give me a quick, energizing briefing for ${today}.
+
+## What's on My Plate
+- ${pendingTasks.length} tasks pending (${aCount} are A-priority)
+- ${habits.length} habits to track today
+- ${goals.length} active goals in progress
+
+### Task Details
+${JSON.stringify(pendingTasks.slice(0, 10), null, 2)}
+
+### Habits
+${JSON.stringify(habits, null, 2)}
+
+Keep it brief: 3-4 bullet points on what matters most today, then a one-sentence motivational close.`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 3. end_of_day_review
+  server.prompt(
+    "end_of_day_review",
+    "Review what got done today and reflect on the day",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const [tasks, habits, focusStats] = await Promise.all([
+        fetchTodayTasks(userId),
+        fetchTodayHabits(userId),
+        fetchTodayFocusStats(userId),
+      ]);
+
+      const today = new Date().toISOString().split("T")[0];
+      const completed = tasks.filter((t) => t.done);
+      const incomplete = tasks.filter((t) => !t.done);
+      const habitsCompleted = habits.filter((h) => h.completed_today);
+
+      const userText = `Help me wrap up my day for ${today} with a structured end-of-day review.
+
+## What I Accomplished
+### Completed Tasks (${completed.length})
+${JSON.stringify(completed, null, 2)}
+
+### Incomplete Tasks (${incomplete.length})
+${JSON.stringify(incomplete, null, 2)}
+
+### Habits Completed (${habitsCompleted.length}/${habits.length})
+${JSON.stringify(habitsCompleted, null, 2)}
+
+### Focus Time
+- Total focus minutes: ${focusStats.totalFocusMinutes}
+- Completed sessions: ${focusStats.completedSessions}
+
+Please provide:
+1. A brief celebration of what I accomplished
+2. Honest assessment of what didn't get done and why
+3. The top 3 tasks to carry into tomorrow
+4. A reflection question for my journal tonight`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 4. productivity_report
+  server.prompt(
+    "productivity_report",
+    "Generate a detailed productivity report for a date range",
+    {
+      from: z.string().describe("Start date in YYYY-MM-DD format"),
+      to: z.string().describe("End date in YYYY-MM-DD format"),
+    },
+    async (args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const [focusSessions, tasks, habitData] = await Promise.all([
+        fetchFocusSessionsForRange(userId, args.from, args.to),
+        fetchTasksForRange(userId, args.from, args.to),
+        fetchHabitLogsForRange(userId, args.from, args.to),
+      ]);
+
+      const completedFocus = focusSessions.filter((s) => s.completed_at != null);
+      const totalFocusMinutes = completedFocus.reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+      const completedTasks = tasks.filter((t) => t.done);
+
+      const userText = `Generate a productivity report for ${args.from} to ${args.to}.
+
+## Task Summary
+- Total tasks: ${tasks.length}
+- Completed: ${completedTasks.length} (${tasks.length > 0 ? Math.round((completedTasks.length / tasks.length) * 100) : 0}% completion rate)
+- By priority: A=${tasks.filter((t) => t.priority === "A" && t.done).length}/${tasks.filter((t) => t.priority === "A").length}, B=${tasks.filter((t) => t.priority === "B" && t.done).length}/${tasks.filter((t) => t.priority === "B").length}, C=${tasks.filter((t) => t.priority === "C" && t.done).length}/${tasks.filter((t) => t.priority === "C").length}
+
+## Focus Sessions
+- Total sessions: ${completedFocus.length}
+- Total focus time: ${totalFocusMinutes} minutes (${Math.round(totalFocusMinutes / 60 * 10) / 10} hours)
+
+## Habit Tracking
+- Habits tracked: ${habitData.habits.length}
+- Total habit completions: ${habitData.logs.length}
+
+Please provide:
+1. Overall productivity score and assessment
+2. Strengths and patterns observed
+3. Areas for improvement
+4. Specific recommendations for the next period`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 5. habit_analysis
+  server.prompt(
+    "habit_analysis",
+    "Analyze habit patterns and suggest improvements",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const habits = await fetchAllHabitsWithStats(userId);
+
+      const strongHabits = habits.filter((h) => h.completionRate >= 70);
+      const weakHabits = habits.filter((h) => h.completionRate < 40);
+
+      const userText = `Analyze my habit patterns and help me build better consistency.
+
+## My Habits (Last 30 Days)
+${JSON.stringify(habits, null, 2)}
+
+## Quick Stats
+- Total habits: ${habits.length}
+- Strong habits (≥70% completion): ${strongHabits.length}
+- Struggling habits (<40% completion): ${weakHabits.length}
+
+Please:
+1. Identify my strongest habits and why they're working
+2. Diagnose the habits I'm struggling with
+3. Suggest habit stacking opportunities (linking weak habits to strong ones)
+4. Recommend 1-2 habits to add or remove based on the patterns
+5. Give me a concrete improvement plan for the next 2 weeks`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 6. goal_check_in
+  server.prompt(
+    "goal_check_in",
+    "Check progress on active goals and identify next actions",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const goals = await fetchActiveGoals(userId);
+
+      const userText = `Help me do a goal check-in and identify what needs attention.
+
+## Active Goals
+${JSON.stringify(goals, null, 2)}
+
+For each goal, please:
+1. Assess whether progress looks on track given any target dates
+2. Identify which goal needs the most attention right now
+3. Suggest 1-3 concrete next actions for the top priority goal
+4. Flag any goals that may need to be revised or abandoned
+5. Give an overall goals health score (1-10) and why`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 7. weekly_trends
+  server.prompt(
+    "weekly_trends",
+    "Compare this week vs last week across all productivity metrics",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      // Calculate this week and last week ranges
+      const now = new Date();
+      const dayOfWeek = now.getDay();
+      const diffToMonday = dayOfWeek === 0 ? -6 : 1 - dayOfWeek;
+
+      const thisMonday = new Date(now);
+      thisMonday.setDate(now.getDate() + diffToMonday);
+      const thisWeekStart = thisMonday.toISOString().split("T")[0];
+
+      const thisSunday = new Date(thisMonday);
+      thisSunday.setDate(thisMonday.getDate() + 6);
+      const thisWeekEnd = thisSunday.toISOString().split("T")[0];
+
+      const lastMonday = new Date(thisMonday);
+      lastMonday.setDate(thisMonday.getDate() - 7);
+      const lastWeekStart = lastMonday.toISOString().split("T")[0];
+
+      const lastSunday = new Date(lastMonday);
+      lastSunday.setDate(lastMonday.getDate() + 6);
+      const lastWeekEnd = lastSunday.toISOString().split("T")[0];
+
+      const [thisWeekTasks, lastWeekTasks, thisWeekFocus, lastWeekFocus, thisWeekHabits, lastWeekHabits] =
+        await Promise.all([
+          fetchTasksForRange(userId, thisWeekStart, thisWeekEnd),
+          fetchTasksForRange(userId, lastWeekStart, lastWeekEnd),
+          fetchFocusSessionsForRange(userId, thisWeekStart, thisWeekEnd),
+          fetchFocusSessionsForRange(userId, lastWeekStart, lastWeekEnd),
+          fetchHabitLogsForRange(userId, thisWeekStart, thisWeekEnd),
+          fetchHabitLogsForRange(userId, lastWeekStart, lastWeekEnd),
+        ]);
+
+      const thisWeekCompleted = thisWeekTasks.filter((t) => t.done);
+      const lastWeekCompleted = lastWeekTasks.filter((t) => t.done);
+
+      const thisWeekFocusMin = thisWeekFocus
+        .filter((s) => s.completed_at)
+        .reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+      const lastWeekFocusMin = lastWeekFocus
+        .filter((s) => s.completed_at)
+        .reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+
+      const userText = `Compare my productivity this week vs last week.
+
+## This Week (${thisWeekStart} – ${thisWeekEnd})
+- Tasks: ${thisWeekCompleted.length}/${thisWeekTasks.length} completed
+- Focus time: ${thisWeekFocusMin} minutes
+- Habit completions: ${thisWeekHabits.logs.length}
+
+## Last Week (${lastWeekStart} – ${lastWeekEnd})
+- Tasks: ${lastWeekCompleted.length}/${lastWeekTasks.length} completed
+- Focus time: ${lastWeekFocusMin} minutes
+- Habit completions: ${lastWeekHabits.logs.length}
+
+Please:
+1. Identify the biggest improvements this week
+2. Flag any areas where I regressed
+3. Explain what likely drove the differences
+4. Give 2-3 specific actions to improve next week`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 8. weekly_review
+  server.prompt(
+    "weekly_review",
+    "Generate a structured weekly review covering wins, losses, and next week's plan",
+    {
+      week_start: z.string().optional().describe("Week start date in YYYY-MM-DD format (defaults to this Monday)"),
+    },
+    async (args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      let weekStart = args.week_start;
+      if (!weekStart) {
+        const now = new Date();
+        const day = now.getDay();
+        const diff = day === 0 ? -6 : 1 - day;
+        now.setDate(now.getDate() + diff);
+        weekStart = now.toISOString().split("T")[0];
+      }
+
+      const weekEndDate = new Date(weekStart);
+      weekEndDate.setDate(weekEndDate.getDate() + 6);
+      const weekEnd = weekEndDate.toISOString().split("T")[0];
+
+      const [tasks, habitData, focusSessions, journal] = await Promise.all([
+        fetchTasksForRange(userId, weekStart, weekEnd),
+        fetchHabitLogsForRange(userId, weekStart, weekEnd),
+        fetchFocusSessionsForRange(userId, weekStart, weekEnd),
+        fetchRecentJournal(userId, 7),
+      ]);
+
+      const completedTasks = tasks.filter((t) => t.done);
+      const completedFocus = focusSessions.filter((s) => s.completed_at);
+      const totalFocusMin = completedFocus.reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+      const weekJournal = journal.filter((e) => e.entry_date >= weekStart! && e.entry_date <= weekEnd);
+
+      const userText = `Generate a structured weekly review for the week of ${weekStart}.
+
+## Week Data
+
+### Tasks
+- Total: ${tasks.length}
+- Completed: ${completedTasks.length}
+- Completion rate: ${tasks.length > 0 ? Math.round((completedTasks.length / tasks.length) * 100) : 0}%
+- Completed titles: ${completedTasks.map((t) => t.title).join(", ") || "none"}
+- Incomplete: ${tasks.filter((t) => !t.done).map((t) => t.title).join(", ") || "none"}
+
+### Habits
+- Tracking ${habitData.habits.length} habits
+- Total completions: ${habitData.logs.length}
+
+### Focus
+- Total focus time: ${totalFocusMin} minutes
+- Sessions completed: ${completedFocus.length}
+
+### Journal
+- Entries written: ${weekJournal.length}
+
+Please structure the review with:
+1. **Wins** — What went well this week?
+2. **Challenges** — What got in the way?
+3. **Lessons** — What did I learn?
+4. **Next week's intention** — Top 3 focus areas
+5. **Carry-forward tasks** — What needs to move to next week?`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 9. journal_prompt
+  server.prompt(
+    "journal_prompt",
+    "Get a thoughtful, personalized journal prompt based on recent activity",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const [recentJournal, tasks, habits] = await Promise.all([
+        fetchRecentJournal(userId, 5),
+        fetchTodayTasks(userId),
+        fetchTodayHabits(userId),
+      ]);
+
+      const today = new Date().toISOString().split("T")[0];
+      const completedToday = tasks.filter((t) => t.done);
+      const habitsCompleted = habits.filter((h) => h.completed_today);
+
+      const recentMoods = recentJournal.filter((e) => e.mood != null).map((e) => e.mood);
+      const avgMood = recentMoods.length > 0
+        ? recentMoods.reduce((a: number, b) => a + (b as number), 0) / recentMoods.length
+        : null;
+
+      const userText = `Generate a thoughtful, personalized journal prompt for me today (${today}).
+
+## Context About My Day
+- Completed ${completedToday.length} tasks including: ${completedToday.slice(0, 3).map((t) => t.title).join(", ") || "none"}
+- Completed ${habitsCompleted.length}/${habits.length} habits
+- Recent mood trend: ${avgMood ? `${avgMood.toFixed(1)}/5 average over last ${recentMoods.length} entries` : "no recent data"}
+
+## Recent Journal Themes
+${recentJournal.slice(0, 3).map((e) => `${e.entry_date}: ${(e.content as string)?.slice(0, 150)}...`).join("\n") || "No recent entries"}
+
+Generate 1 deep, specific journal prompt that:
+- Connects to what I actually did today
+- Encourages meaningful reflection (not surface-level)
+- Ties to growth or patterns you notice
+- Feels personal, not generic
+
+Follow with 2-3 shorter follow-up questions if they want to go deeper.`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 10. workout_suggestion
+  server.prompt(
+    "workout_suggestion",
+    "Suggest a workout based on recent training history and available templates",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const [recentWorkouts, templates] = await Promise.all([
+        fetchRecentWorkouts(userId, 7),
+        fetchWorkoutTemplates(userId),
+      ]);
+
+      const today = new Date().toISOString().split("T")[0];
+
+      const userText = `Suggest the best workout for me today (${today}).
+
+## Recent Workouts (Last 7)
+${JSON.stringify(recentWorkouts, null, 2)}
+
+## My Saved Templates
+${JSON.stringify(templates, null, 2)}
+
+Please:
+1. Identify what muscle groups/types I've recently trained
+2. Recommend what I should focus on today based on recovery needs
+3. Suggest either a specific saved template or a custom workout plan
+4. Include sets/reps if creating a custom plan
+5. Estimate total time needed`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 11. goal_planning
+  server.prompt(
+    "goal_planning",
+    "Break down a goal into actionable tasks and a step-by-step plan",
+    {
+      goal_id: z.string().describe("Goal ID to plan for"),
+    },
+    async (args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const goal = await fetchGoalById(userId, args.goal_id);
+
+      if (!goal) {
+        return {
+          messages: [{ role: "user" as const, content: { type: "text" as const, text: "Goal not found" } }],
+        };
+      }
+
+      const userText = `Help me create a concrete action plan for this goal.
+
+## Goal Details
+${JSON.stringify(goal, null, 2)}
+
+Please provide:
+1. **Milestone breakdown** — 3-5 major milestones to reach this goal
+2. **Weekly task plan** — Specific tasks for the first 2 weeks (formatted as a task list I can add to Daily Agent)
+3. **Daily habits to support it** — 1-2 daily habits that would accelerate progress
+4. **Potential blockers** — What might get in the way and how to pre-empt them
+5. **Success metrics** — How will I know I'm making real progress?
+
+Format tasks as: [PRIORITY: A/B/C] Task title`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 12. space_planning
+  server.prompt(
+    "space_planning",
+    "Plan and prioritize work within a specific space or project",
+    {
+      space_id: z.string().optional().describe("Space ID to plan for (if omitted, shows all unassigned tasks)"),
+    },
+    async (args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const [tasks, spaces] = await Promise.all([
+        fetchSpaceTasks(userId, args.space_id),
+        (async () => {
+          const supabase = getServiceClient();
+          const { data } = await supabase
+            .from("spaces")
+            .select("id, name, description, status")
+            .eq("user_id", userId);
+          return data ?? [];
+        })(),
+      ]);
+
+      const space = args.space_id ? spaces.find((s) => s.id === args.space_id) : null;
+
+      const userText = `Help me plan and prioritize work${space ? ` in the "${space.name}" space` : " across all my spaces"}.
+
+${space ? `## Space: ${space.name}\n${space.description ? `Description: ${space.description}` : ""}` : "## All Spaces\n" + JSON.stringify(spaces, null, 2)}
+
+## Current Tasks (${tasks.length} open)
+${JSON.stringify(tasks, null, 2)}
+
+Please:
+1. Group tasks by theme or dependency
+2. Identify the highest-impact tasks to tackle first
+3. Flag any tasks that seem stale or could be deleted
+4. Suggest a sprint plan: what to focus on this week vs later
+5. Identify any missing tasks based on the space's apparent goals`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+
+  // 13. week_planning
+  server.prompt(
+    "week_planning",
+    "Plan the upcoming week with priorities, goals alignment, and a day-by-day schedule",
+    {},
+    async (_args, extra: Extra) => {
+      const userId = getUserId(extra);
+      if (!userId) return { messages: [{ role: "user" as const, content: { type: "text" as const, text: "Not authenticated" } }] };
+
+      const [tasks, goals, habits] = await Promise.all([
+        fetchTodayTasks(userId),
+        fetchActiveGoals(userId),
+        fetchAllHabitsWithStats(userId),
+      ]);
+
+      const now = new Date();
+      const dayOfWeek = now.getDay();
+      const diffToMonday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
+      const nextMonday = new Date(now);
+      nextMonday.setDate(now.getDate() + diffToMonday);
+      const nextWeekStart = nextMonday.toISOString().split("T")[0];
+
+      const nextSunday = new Date(nextMonday);
+      nextSunday.setDate(nextMonday.getDate() + 6);
+      const nextWeekEnd = nextSunday.toISOString().split("T")[0];
+
+      const pendingTasks = tasks.filter((t) => !t.done);
+
+      const userText = `Help me plan my upcoming week (${nextWeekStart} – ${nextWeekEnd}).
+
+## Carry-Forward Tasks (${pendingTasks.length} incomplete)
+${JSON.stringify(pendingTasks, null, 2)}
+
+## Active Goals
+${JSON.stringify(goals, null, 2)}
+
+## Habit Consistency (Last 30 Days)
+${JSON.stringify(habits.map((h) => ({ name: h.name, completionRate: h.completionRate })), null, 2)}
+
+Please create:
+1. **Weekly theme/intention** — One sentence focus for the week
+2. **Top 5 priority tasks** — The must-do items this week (mark A-priority)
+3. **Goal actions** — 1 concrete task per active goal to advance it this week
+4. **Day-by-day sketch** — Light schedule suggestion (Mon–Fri)
+5. **Habit focus** — Which 1-2 habits to prioritize building this week based on consistency data`;
+
+      return {
+        messages: [
+          { role: "user" as const, content: { type: "text" as const, text: userText } },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/queries/__tests__/tasks.test.ts
+++ b/src/lib/mcp/queries/__tests__/tasks.test.ts
@@ -1,0 +1,346 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SupabaseClient } from "@supabase/supabase-js";
+import {
+  getTasksForDate,
+  getOverdueTasks,
+  createTask,
+  completeTask,
+  deleteTask,
+  Task,
+} from "@/lib/mcp/queries/tasks";
+
+// ---------------------------------------------------------------------------
+// Mock getToday so tests are date-independent
+// ---------------------------------------------------------------------------
+
+vi.mock("@/lib/dates", () => ({
+  getToday: vi.fn(() => "2026-03-23"),
+}));
+
+import { getToday } from "@/lib/dates";
+const mockGetToday = vi.mocked(getToday);
+
+// ---------------------------------------------------------------------------
+// Chainable Supabase mock builder
+// ---------------------------------------------------------------------------
+
+type QueryResult<T> = { data: T; error: { message: string } | null };
+
+interface MockBuilder {
+  select: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  or: ReturnType<typeof vi.fn>;
+  lt: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+  _resolve: (result: QueryResult<unknown>) => void;
+}
+
+function createMockSupabase(defaultResult: QueryResult<unknown> = { data: [], error: null }) {
+  let resolvedResult = defaultResult;
+
+  const builder: MockBuilder = {
+    select: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    or: vi.fn().mockReturnThis(),
+    lt: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    single: vi.fn().mockImplementation(() => Promise.resolve(resolvedResult)),
+    _resolve: (r) => {
+      resolvedResult = r;
+    },
+  };
+
+  // Make the builder thenable so `await supabase.from(...).select(...).eq(...)` resolves
+  const proxy = new Proxy(builder, {
+    get(target, prop) {
+      if (prop === "then") {
+        return (resolve: (value: QueryResult<unknown>) => void) => resolve(resolvedResult);
+      }
+      return target[prop as keyof MockBuilder];
+    },
+  });
+
+  // All chainable methods return the same proxy
+  for (const method of ["select", "insert", "update", "delete", "eq", "or", "lt", "order"] as const) {
+    builder[method].mockReturnValue(proxy);
+  }
+  builder.single.mockImplementation(() => Promise.resolve(resolvedResult));
+
+  const supabase = {
+    from: vi.fn().mockReturnValue(proxy),
+    _builder: builder,
+    /** Override what the next awaited query resolves to */
+    setResult(r: QueryResult<unknown>) {
+      resolvedResult = r;
+      builder.single.mockImplementation(() => Promise.resolve(r));
+    },
+  };
+
+  return supabase;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TODAY = "2026-03-23";
+
+const sampleTask: Task = {
+  id: "task-1",
+  user_id: "user-abc",
+  title: "Write tests",
+  notes: null,
+  priority: "A1",
+  task_date: TODAY,
+  space_id: null,
+  goal_id: null,
+  done: false,
+  done_at: null,
+  recurrence: null,
+  sort_order: 0,
+  created_at: "2026-03-23T00:00:00Z",
+  updated_at: "2026-03-23T00:00:00Z",
+};
+
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetToday.mockReturnValue(TODAY);
+});
+
+// ---------------------------------------------------------------------------
+// getTasksForDate
+// ---------------------------------------------------------------------------
+
+describe("getTasksForDate", () => {
+  it("uses .or() filter when date is today (includes overdue)", async () => {
+    const mock = createMockSupabase({ data: [sampleTask], error: null });
+
+    await getTasksForDate(mock as unknown as SupabaseClient, "user-abc", TODAY);
+
+    expect(mock._builder.or).toHaveBeenCalledWith(
+      `task_date.eq.${TODAY},and(task_date.lt.${TODAY},done.eq.false)`
+    );
+  });
+
+  it("uses .or() filter when no date is passed (defaults to today)", async () => {
+    const mock = createMockSupabase({ data: [sampleTask], error: null });
+
+    await getTasksForDate(mock as unknown as SupabaseClient, "user-abc");
+
+    expect(mock._builder.or).toHaveBeenCalled();
+  });
+
+  it("uses .eq('task_date', ...) filter for a specific past date", async () => {
+    const pastDate = "2026-03-01";
+    const mock = createMockSupabase({ data: [sampleTask], error: null });
+
+    await getTasksForDate(mock as unknown as SupabaseClient, "user-abc", pastDate);
+
+    // Should NOT use .or() for past date
+    expect(mock._builder.or).not.toHaveBeenCalled();
+    // Should use eq with the task_date
+    const eqCalls = mock._builder.eq.mock.calls as [string, unknown][];
+    const taskDateCall = eqCalls.find(([col]) => col === "task_date");
+    expect(taskDateCall).toBeDefined();
+    expect(taskDateCall![1]).toBe(pastDate);
+  });
+
+  it("returns task list on success", async () => {
+    const mock = createMockSupabase({ data: [sampleTask], error: null });
+
+    const result = await getTasksForDate(mock as unknown as SupabaseClient, "user-abc", TODAY);
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([sampleTask]);
+  });
+
+  it("returns error when supabase returns an error", async () => {
+    const mock = createMockSupabase({ data: null as unknown as Task[], error: { message: "DB error" } });
+
+    const result = await getTasksForDate(mock as unknown as SupabaseClient, "user-abc", TODAY);
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBe("DB error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getOverdueTasks
+// ---------------------------------------------------------------------------
+
+describe("getOverdueTasks", () => {
+  it("queries tasks with task_date less than today and done=false", async () => {
+    const mock = createMockSupabase({ data: [], error: null });
+
+    await getOverdueTasks(mock as unknown as SupabaseClient, "user-abc");
+
+    expect(mock._builder.lt).toHaveBeenCalledWith("task_date", TODAY);
+    const eqCalls = mock._builder.eq.mock.calls as [string, unknown][];
+    const doneCall = eqCalls.find(([col]) => col === "done");
+    expect(doneCall).toBeDefined();
+    expect(doneCall![1]).toBe(false);
+  });
+
+  it("returns error when supabase returns an error", async () => {
+    const mock = createMockSupabase({
+      data: null as unknown as Task[],
+      error: { message: "overdue error" },
+    });
+
+    const result = await getOverdueTasks(mock as unknown as SupabaseClient, "user-abc");
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBe("overdue error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createTask
+// ---------------------------------------------------------------------------
+
+describe("createTask", () => {
+  it("inserts with correct fields and defaults priority to B1", async () => {
+    const mock = createMockSupabase();
+    mock.setResult({ data: { ...sampleTask, priority: "B1" }, error: null });
+
+    await createTask(mock as unknown as SupabaseClient, "user-abc", { title: "New task" });
+
+    const insertCall = mock._builder.insert.mock.calls[0][0] as Record<string, unknown>;
+    expect(insertCall.user_id).toBe("user-abc");
+    expect(insertCall.title).toBe("New task");
+    expect(insertCall.priority).toBe("B1");
+    expect(insertCall.task_date).toBe(TODAY);
+    expect(insertCall.notes).toBeNull();
+    expect(insertCall.space_id).toBeNull();
+    expect(insertCall.goal_id).toBeNull();
+  });
+
+  it("uses provided priority when given", async () => {
+    const mock = createMockSupabase();
+    mock.setResult({ data: { ...sampleTask, priority: "A1" }, error: null });
+
+    await createTask(mock as unknown as SupabaseClient, "user-abc", {
+      title: "Urgent task",
+      priority: "A1",
+    });
+
+    const insertCall = mock._builder.insert.mock.calls[0][0] as Record<string, unknown>;
+    expect(insertCall.priority).toBe("A1");
+  });
+
+  it("uses provided task_date when given", async () => {
+    const mock = createMockSupabase();
+    mock.setResult({ data: sampleTask, error: null });
+
+    await createTask(mock as unknown as SupabaseClient, "user-abc", {
+      title: "Future task",
+      task_date: "2026-04-01",
+    });
+
+    const insertCall = mock._builder.insert.mock.calls[0][0] as Record<string, unknown>;
+    expect(insertCall.task_date).toBe("2026-04-01");
+  });
+
+  it("returns error when supabase returns an error", async () => {
+    const mock = createMockSupabase();
+    mock.setResult({ data: null, error: { message: "insert failed" } });
+
+    const result = await createTask(mock as unknown as SupabaseClient, "user-abc", {
+      title: "Bad task",
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBe("insert failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeTask
+// ---------------------------------------------------------------------------
+
+describe("completeTask", () => {
+  it("sets done=true and done_at to an ISO string", async () => {
+    const completedTask = { ...sampleTask, done: true, done_at: new Date().toISOString() };
+    const mock = createMockSupabase();
+    mock.setResult({ data: completedTask, error: null });
+
+    await completeTask(mock as unknown as SupabaseClient, "user-abc", "task-1");
+
+    const updateCall = mock._builder.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(updateCall.done).toBe(true);
+    expect(typeof updateCall.done_at).toBe("string");
+    // Verify it's a valid ISO 8601 date string
+    expect(() => new Date(updateCall.done_at as string).toISOString()).not.toThrow();
+  });
+
+  it("filters by task id and user_id", async () => {
+    const completedTask = { ...sampleTask, done: true };
+    const mock = createMockSupabase();
+    mock.setResult({ data: completedTask, error: null });
+
+    await completeTask(mock as unknown as SupabaseClient, "user-abc", "task-1");
+
+    const eqCalls = mock._builder.eq.mock.calls as [string, unknown][];
+    const idCall = eqCalls.find(([col]) => col === "id");
+    const userCall = eqCalls.find(([col]) => col === "user_id");
+    expect(idCall![1]).toBe("task-1");
+    expect(userCall![1]).toBe("user-abc");
+  });
+
+  it("returns error when supabase returns an error", async () => {
+    const mock = createMockSupabase();
+    mock.setResult({ data: null, error: { message: "update failed" } });
+
+    const result = await completeTask(mock as unknown as SupabaseClient, "user-abc", "task-1");
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBe("update failed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteTask
+// ---------------------------------------------------------------------------
+
+describe("deleteTask", () => {
+  it("deletes with correct user_id and task_id filters", async () => {
+    const mock = createMockSupabase({ data: null, error: null });
+
+    await deleteTask(mock as unknown as SupabaseClient, "user-abc", "task-1");
+
+    expect(mock.from).toHaveBeenCalledWith("tasks");
+    expect(mock._builder.delete).toHaveBeenCalled();
+    const eqCalls = mock._builder.eq.mock.calls as [string, unknown][];
+    const idCall = eqCalls.find(([col]) => col === "id");
+    const userCall = eqCalls.find(([col]) => col === "user_id");
+    expect(idCall![1]).toBe("task-1");
+    expect(userCall![1]).toBe("user-abc");
+  });
+
+  it("returns { success: true } on success", async () => {
+    const mock = createMockSupabase({ data: null, error: null });
+
+    const result = await deleteTask(mock as unknown as SupabaseClient, "user-abc", "task-1");
+
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual({ success: true });
+  });
+
+  it("returns error when supabase returns an error", async () => {
+    const mock = createMockSupabase({ data: null, error: { message: "delete failed" } });
+
+    const result = await deleteTask(mock as unknown as SupabaseClient, "user-abc", "task-1");
+
+    expect(result.data).toBeNull();
+    expect(result.error).toBe("delete failed");
+  });
+});

--- a/src/lib/mcp/queries/briefings.ts
+++ b/src/lib/mcp/queries/briefings.ts
@@ -1,0 +1,45 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { getToday } from "@/lib/dates";
+
+export interface DailyBriefing {
+  id: string;
+  user_id: string;
+  briefing_date: string;
+  content: string;
+  created_at: string;
+}
+
+/** Get today's cached daily briefing, if it exists */
+export async function getTodayBriefing(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<QueryResult<DailyBriefing | null>> {
+  try {
+    const today = getToday();
+
+    const { data, error } = await supabase
+      .from("daily_briefings")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("briefing_date", today)
+      .maybeSingle();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as DailyBriefing | null, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+/**
+ * Generate a new daily briefing via MCP.
+ * Briefing generation requires AI model resolution which is not available in the MCP query layer.
+ * Use the /api/briefing endpoint directly for generation.
+ */
+export async function generateBriefing(
+  _supabase: SupabaseClient,
+  _userId: string
+): Promise<QueryResult<never>> {
+  return { data: null, error: "Briefing generation via MCP coming soon" };
+}

--- a/src/lib/mcp/queries/briefings.ts
+++ b/src/lib/mcp/queries/briefings.ts
@@ -37,9 +37,7 @@ export async function getTodayBriefing(
  * Briefing generation requires AI model resolution which is not available in the MCP query layer.
  * Use the /api/briefing endpoint directly for generation.
  */
-export async function generateBriefing(
-  _supabase: SupabaseClient,
-  _userId: string
-): Promise<QueryResult<never>> {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export async function generateBriefing(supabase: SupabaseClient, userId: string): Promise<QueryResult<never>> {
   return { data: null, error: "Briefing generation via MCP coming soon" };
 }

--- a/src/lib/mcp/queries/calendar.ts
+++ b/src/lib/mcp/queries/calendar.ts
@@ -1,0 +1,288 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { getToday, startOfWeek, endOfWeek, getCalendarGridDates } from "@/lib/dates";
+
+export interface DayTask {
+  id: string;
+  title: string;
+  priority: string;
+  done: boolean;
+}
+
+export interface DayHabit {
+  name: string;
+  color: string | null;
+  completed: boolean;
+}
+
+export interface DayJournal {
+  id: string;
+  mood: number | null;
+  content: string;
+}
+
+export interface DayWorkout {
+  id: string;
+  name: string;
+  duration_minutes: number | null;
+}
+
+export interface DayFocusSession {
+  id: string;
+  duration_minutes: number;
+  task_title: string | null;
+  status: string;
+}
+
+export interface DayDetail {
+  date: string;
+  tasks: DayTask[];
+  habits: DayHabit[];
+  journal: { id: string; mood: number | null; content: string } | null;
+  workouts: DayWorkout[];
+  focus: DayFocusSession[];
+}
+
+export interface DaySummary {
+  tasks: { total: number; done: number; hasA: boolean; hasB: boolean; hasC: boolean };
+  habits: { total: number; completed: number; colors: string[] };
+  journal: { hasEntry: boolean; mood: number | null };
+  workouts: { count: number };
+  focus: { sessions: number; minutes: number };
+}
+
+export interface WeekSummary {
+  weekStart: string;
+  weekEnd: string;
+  days: Record<string, DaySummary>;
+}
+
+/** Get detailed data for a single day */
+export async function getDaySummary(
+  supabase: SupabaseClient,
+  userId: string,
+  date: string
+): Promise<QueryResult<DayDetail>> {
+  try {
+    const [tasksResult, habitLogsResult, journalResult, workoutsResult, focusResult] =
+      await Promise.all([
+        supabase
+          .from("tasks")
+          .select("id, title, priority, done")
+          .eq("user_id", userId)
+          .eq("task_date", date)
+          .order("sort_order", { ascending: true }),
+        supabase
+          .from("habit_logs")
+          .select("habit_id")
+          .eq("user_id", userId)
+          .eq("log_date", date),
+        supabase
+          .from("journal_entries")
+          .select("id, mood, content")
+          .eq("user_id", userId)
+          .eq("entry_date", date)
+          .maybeSingle(),
+        supabase
+          .from("workout_logs")
+          .select("id, name, duration_minutes")
+          .eq("user_id", userId)
+          .eq("log_date", date)
+          .order("created_at", { ascending: false }),
+        supabase
+          .from("focus_sessions")
+          .select("id, duration_minutes, task_id, status")
+          .eq("user_id", userId)
+          .gte("started_at", `${date}T00:00:00`)
+          .lte("started_at", `${date}T23:59:59`)
+          .in("status", ["completed", "active"])
+          .order("started_at", { ascending: false }),
+      ]);
+
+    const habitsResult = await supabase
+      .from("habits")
+      .select("id, name, color, target_days")
+      .eq("user_id", userId)
+      .eq("archived", false);
+
+    const d = new Date(date + "T00:00:00");
+    const dow = d.getDay() === 0 ? 7 : d.getDay();
+    const completedHabitIds = new Set(
+      (habitLogsResult.data ?? []).map((hl: { habit_id: string }) => hl.habit_id)
+    );
+
+    const habits: DayHabit[] = (habitsResult.data ?? [])
+      .filter((h: { target_days: number[] }) => h.target_days?.includes(dow))
+      .map((h: { name: string; color: string | null; id: string }) => ({
+        name: h.name,
+        color: h.color,
+        completed: completedHabitIds.has(h.id),
+      }));
+
+    if (tasksResult.error) return { data: null, error: tasksResult.error.message };
+
+    const detail: DayDetail = {
+      date,
+      tasks: (tasksResult.data ?? []).map((t: { id: string; title: string; priority: string; done: boolean }) => ({
+        id: t.id,
+        title: t.title,
+        priority: t.priority,
+        done: t.done,
+      })),
+      habits,
+      journal: journalResult.data
+        ? {
+            id: journalResult.data.id as string,
+            mood: journalResult.data.mood as number | null,
+            content: journalResult.data.content as string,
+          }
+        : null,
+      workouts: (workoutsResult.data ?? []).map((w: { id: string; name: string; duration_minutes: number | null }) => ({
+        id: w.id,
+        name: w.name,
+        duration_minutes: w.duration_minutes,
+      })),
+      focus: (focusResult.data ?? []).map((f: { id: string; duration_minutes: number; status: string }) => ({
+        id: f.id,
+        duration_minutes: f.duration_minutes,
+        task_title: null,
+        status: f.status,
+      })),
+    };
+
+    return { data: detail, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+/** Get aggregated summary for a week (defaults to the current week) */
+export async function getWeekSummary(
+  supabase: SupabaseClient,
+  userId: string,
+  weekStartParam?: string
+): Promise<QueryResult<WeekSummary>> {
+  try {
+    const today = getToday();
+    const weekStart = weekStartParam || startOfWeek(today);
+    const weekEnd = endOfWeek(weekStart);
+
+    const gridDates = getCalendarGridDates(today.slice(0, 7));
+    const startDate = weekStart;
+    const endDate = weekEnd;
+
+    const [tasksResult, habitLogsResult, habitsResult, journalResult, workoutsResult, focusResult] =
+      await Promise.all([
+        supabase
+          .from("tasks")
+          .select("task_date, priority, done")
+          .eq("user_id", userId)
+          .gte("task_date", startDate)
+          .lte("task_date", endDate),
+        supabase
+          .from("habit_logs")
+          .select("log_date, habit_id")
+          .eq("user_id", userId)
+          .gte("log_date", startDate)
+          .lte("log_date", endDate),
+        supabase
+          .from("habits")
+          .select("id, color, target_days")
+          .eq("user_id", userId)
+          .eq("archived", false),
+        supabase
+          .from("journal_entries")
+          .select("entry_date, mood")
+          .eq("user_id", userId)
+          .gte("entry_date", startDate)
+          .lte("entry_date", endDate),
+        supabase
+          .from("workout_logs")
+          .select("log_date")
+          .eq("user_id", userId)
+          .gte("log_date", startDate)
+          .lte("log_date", endDate),
+        supabase
+          .from("focus_sessions")
+          .select("started_at, duration_minutes, status")
+          .eq("user_id", userId)
+          .gte("started_at", `${startDate}T00:00:00`)
+          .lte("started_at", `${endDate}T23:59:59`)
+          .in("status", ["completed", "active"]),
+      ]);
+
+    if (tasksResult.error) return { data: null, error: tasksResult.error.message };
+
+    const habitMap = new Map<string, { color: string | null; targetDays: number[] }>();
+    for (const h of habitsResult.data ?? []) {
+      habitMap.set(h.id, { color: h.color, targetDays: h.target_days ?? [] });
+    }
+
+    const summaries: Record<string, DaySummary> = {};
+
+    const ensureDay = (date: string): DaySummary => {
+      if (!summaries[date]) {
+        summaries[date] = {
+          tasks: { total: 0, done: 0, hasA: false, hasB: false, hasC: false },
+          habits: { total: 0, completed: 0, colors: [] },
+          journal: { hasEntry: false, mood: null },
+          workouts: { count: 0 },
+          focus: { sessions: 0, minutes: 0 },
+        };
+      }
+      return summaries[date];
+    };
+
+    for (const t of tasksResult.data ?? []) {
+      const day = ensureDay(t.task_date);
+      day.tasks.total++;
+      if (t.done) day.tasks.done++;
+      const prio = String(t.priority ?? "")[0];
+      if (prio === "A") day.tasks.hasA = true;
+      else if (prio === "B") day.tasks.hasB = true;
+      else if (prio === "C") day.tasks.hasC = true;
+    }
+
+    for (const hl of habitLogsResult.data ?? []) {
+      const day = ensureDay(hl.log_date);
+      day.habits.completed++;
+      const habit = habitMap.get(hl.habit_id);
+      if (habit?.color && !day.habits.colors.includes(habit.color)) {
+        day.habits.colors.push(habit.color);
+      }
+    }
+
+    for (const date of gridDates.filter((d) => d >= weekStart && d <= weekEnd)) {
+      const d = new Date(date + "T00:00:00");
+      const dow = d.getDay() === 0 ? 7 : d.getDay();
+      let expectedCount = 0;
+      for (const [, habit] of habitMap) {
+        if (habit.targetDays.includes(dow)) expectedCount++;
+      }
+      if (expectedCount > 0) {
+        ensureDay(date).habits.total = expectedCount;
+      }
+    }
+
+    for (const j of journalResult.data ?? []) {
+      const day = ensureDay(j.entry_date);
+      day.journal.hasEntry = true;
+      day.journal.mood = j.mood;
+    }
+
+    for (const w of workoutsResult.data ?? []) {
+      ensureDay(w.log_date).workouts.count++;
+    }
+
+    for (const f of focusResult.data ?? []) {
+      const date = f.started_at.split("T")[0];
+      const day = ensureDay(date);
+      day.focus.sessions++;
+      day.focus.minutes += f.duration_minutes ?? 0;
+    }
+
+    return { data: { weekStart, weekEnd, days: summaries }, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/dashboard.ts
+++ b/src/lib/mcp/queries/dashboard.ts
@@ -1,0 +1,180 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { getToday } from "@/lib/dates";
+
+export interface DashboardTask {
+  id: string;
+  title: string;
+  priority: string;
+  done: boolean;
+  done_at: string | null;
+  task_date: string;
+}
+
+export interface DashboardGoal {
+  id: string;
+  title: string;
+  progress: number;
+  category: string | null;
+  target_date: string | null;
+}
+
+export interface DashboardSnapshot {
+  tasks: {
+    total: number;
+    done: number;
+    topPriorities: DashboardTask[];
+  };
+  habits: {
+    total: number;
+    completedToday: number;
+  };
+  journal: {
+    hasEntry: boolean;
+    mood: number | null;
+  };
+  workouts: {
+    todayName: string | null;
+    weekCount: number;
+  };
+  focus: {
+    todayMinutes: number;
+    todaySessions: number;
+  };
+  goals: {
+    activeCount: number;
+    topGoals: DashboardGoal[];
+  };
+}
+
+export async function getDashboardSnapshot(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<QueryResult<DashboardSnapshot>> {
+  try {
+    const today = getToday();
+    const weekAgo = new Date(Date.now() - 7 * 86400000).toISOString().slice(0, 10);
+
+    const [
+      tasksAllResult,
+      tasksPriorityResult,
+      habitsResult,
+      habitLogsResult,
+      journalResult,
+      workoutTodayResult,
+      workoutWeekResult,
+      focusResult,
+      goalsResult,
+    ] = await Promise.all([
+      supabase
+        .from("tasks")
+        .select("done")
+        .eq("user_id", userId)
+        .eq("task_date", today),
+      supabase
+        .from("tasks")
+        .select("id, title, priority, done, done_at, task_date")
+        .eq("user_id", userId)
+        .eq("task_date", today)
+        .eq("done", false)
+        .order("sort_order", { ascending: true })
+        .limit(3),
+      supabase
+        .from("habits")
+        .select("id, name")
+        .eq("user_id", userId)
+        .eq("archived", false),
+      supabase
+        .from("habit_logs")
+        .select("habit_id")
+        .eq("user_id", userId)
+        .eq("log_date", today),
+      supabase
+        .from("journal_entries")
+        .select("mood")
+        .eq("user_id", userId)
+        .eq("entry_date", today)
+        .maybeSingle(),
+      supabase
+        .from("workout_logs")
+        .select("name")
+        .eq("user_id", userId)
+        .eq("log_date", today)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from("workout_logs")
+        .select("id")
+        .eq("user_id", userId)
+        .gte("log_date", weekAgo)
+        .lte("log_date", today),
+      supabase
+        .from("focus_sessions")
+        .select("duration_minutes")
+        .eq("user_id", userId)
+        .eq("status", "completed")
+        .gte("started_at", `${today}T00:00:00.000Z`),
+      supabase
+        .from("goals")
+        .select("id, title, progress, category, target_date")
+        .eq("user_id", userId)
+        .eq("status", "active")
+        .order("target_date", { ascending: true, nullsFirst: false })
+        .limit(3),
+    ]);
+
+    if (tasksAllResult.error) return { data: null, error: tasksAllResult.error.message };
+
+    const tasks = tasksAllResult.data ?? [];
+    const totalTasks = tasks.length;
+    const doneTasks = tasks.filter((t: { done: boolean }) => t.done).length;
+
+    const habits = habitsResult.data ?? [];
+    const completedHabitIds = new Set(
+      (habitLogsResult.data ?? []).map((l: { habit_id: string }) => l.habit_id)
+    );
+    const completedHabitsToday = habits.filter((h: { id: string }) =>
+      completedHabitIds.has(h.id)
+    ).length;
+
+    const focusSessions = focusResult.data ?? [];
+    const todayFocusMinutes = focusSessions.reduce(
+      (s: number, f: { duration_minutes: number | null }) => s + (f.duration_minutes ?? 0),
+      0
+    );
+
+    return {
+      data: {
+        tasks: {
+          total: totalTasks,
+          done: doneTasks,
+          topPriorities: (tasksPriorityResult.data ?? []) as DashboardTask[],
+        },
+        habits: {
+          total: habits.length,
+          completedToday: completedHabitsToday,
+        },
+        journal: {
+          hasEntry: journalResult.data !== null,
+          mood: (journalResult.data?.mood as number | null) ?? null,
+        },
+        workouts: {
+          todayName: (workoutTodayResult.data?.name as string | null) ?? null,
+          weekCount: workoutWeekResult.data?.length ?? 0,
+        },
+        focus: {
+          todayMinutes: todayFocusMinutes,
+          todaySessions: focusSessions.length,
+        },
+        goals: {
+          activeCount: goalsResult.data?.length ?? 0,
+          topGoals: (goalsResult.data ?? []) as DashboardGoal[],
+        },
+      },
+      error: null,
+    };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/focus.ts
+++ b/src/lib/mcp/queries/focus.ts
@@ -1,0 +1,138 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { getToday } from "@/lib/dates";
+
+export interface FocusSession {
+  id: string;
+  user_id: string;
+  task_id: string | null;
+  duration_minutes: number;
+  break_minutes: number;
+  notes: string | null;
+  started_at: string;
+  completed_at: string | null;
+  status: "active" | "completed" | "cancelled";
+}
+
+export interface TodayFocusStats {
+  totalMinutes: number;
+  sessionCount: number;
+}
+
+export interface StartFocusSessionInput {
+  duration_minutes: number;
+  task_id?: string;
+  break_minutes?: number;
+  notes?: string;
+}
+
+export interface GetFocusSessionsParams {
+  from?: string;
+  to?: string;
+}
+
+export async function getFocusSessions(
+  supabase: SupabaseClient,
+  userId: string,
+  params?: GetFocusSessionsParams
+): Promise<QueryResult<FocusSession[]>> {
+  try {
+    const defaultFrom = new Date();
+    defaultFrom.setDate(defaultFrom.getDate() - 7);
+
+    const from = params?.from || defaultFrom.toISOString();
+    const to = params?.to || new Date().toISOString();
+
+    const { data, error } = await supabase
+      .from("focus_sessions")
+      .select("*")
+      .eq("user_id", userId)
+      .gte("started_at", from)
+      .lte("started_at", to)
+      .order("started_at", { ascending: false });
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as FocusSession[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function getTodayFocusStats(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<QueryResult<TodayFocusStats>> {
+  try {
+    const today = getToday();
+
+    const { data, error } = await supabase
+      .from("focus_sessions")
+      .select("duration_minutes")
+      .eq("user_id", userId)
+      .eq("status", "completed")
+      .gte("started_at", `${today}T00:00:00.000Z`);
+
+    if (error) return { data: null, error: error.message };
+
+    const sessions = data ?? [];
+    const totalMinutes = sessions.reduce((s, f) => s + (f.duration_minutes ?? 0), 0);
+
+    return {
+      data: { totalMinutes, sessionCount: sessions.length },
+      error: null,
+    };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function startFocusSession(
+  supabase: SupabaseClient,
+  userId: string,
+  input: StartFocusSessionInput
+): Promise<QueryResult<FocusSession>> {
+  try {
+    const { data, error } = await supabase
+      .from("focus_sessions")
+      .insert({
+        user_id: userId,
+        task_id: input.task_id ?? null,
+        duration_minutes: input.duration_minutes,
+        break_minutes: typeof input.break_minutes === "number" ? input.break_minutes : 0,
+        notes: input.notes ?? null,
+        started_at: new Date().toISOString(),
+        status: "active",
+      })
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as FocusSession, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function completeFocusSession(
+  supabase: SupabaseClient,
+  userId: string,
+  sessionId: string
+): Promise<QueryResult<FocusSession>> {
+  try {
+    const { data, error } = await supabase
+      .from("focus_sessions")
+      .update({
+        status: "completed",
+        completed_at: new Date().toISOString(),
+      })
+      .eq("id", sessionId)
+      .eq("user_id", userId)
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as FocusSession, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/goals.ts
+++ b/src/lib/mcp/queries/goals.ts
@@ -1,0 +1,161 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { getToday } from "@/lib/dates";
+
+export interface Goal {
+  id: string;
+  user_id: string;
+  title: string;
+  description: string | null;
+  category: string | null;
+  status: "active" | "completed" | "abandoned";
+  progress: number;
+  progress_mode: string | null;
+  target_date: string | null;
+  sort_order: number;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateGoalInput {
+  title: string;
+  description?: string;
+  category?: string;
+  target_date?: string;
+  progress_mode?: string;
+}
+
+export interface UpdateGoalFields {
+  title?: string;
+  description?: string | null;
+  status?: string;
+  progress?: number;
+  target_date?: string | null;
+}
+
+export async function getGoals(
+  supabase: SupabaseClient,
+  userId: string,
+  status = "active"
+): Promise<QueryResult<Goal[]>> {
+  try {
+    let query = supabase
+      .from("goals")
+      .select("*")
+      .eq("user_id", userId)
+      .order("sort_order", { ascending: true })
+      .order("created_at", { ascending: false });
+
+    if (status !== "all") {
+      query = query.eq("status", status as "active" | "completed" | "abandoned");
+    }
+
+    const { data, error } = await query;
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Goal[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function createGoal(
+  supabase: SupabaseClient,
+  userId: string,
+  input: CreateGoalInput
+): Promise<QueryResult<Goal>> {
+  try {
+    const { data, error } = await supabase
+      .from("goals")
+      .insert({
+        user_id: userId,
+        title: input.title.trim(),
+        ...(input.description ? { description: input.description } : {}),
+        ...(input.category ? { category: input.category } : {}),
+        ...(input.target_date ? { target_date: input.target_date } : {}),
+        ...(input.progress_mode ? { progress_mode: input.progress_mode } : {}),
+      })
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Goal, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function updateGoal(
+  supabase: SupabaseClient,
+  userId: string,
+  goalId: string,
+  fields: UpdateGoalFields
+): Promise<QueryResult<Goal>> {
+  try {
+    const allowedFields: Record<string, unknown> = {};
+
+    if (typeof fields.title === "string") allowedFields.title = fields.title;
+    if (typeof fields.description === "string" || fields.description === null)
+      allowedFields.description = fields.description;
+    if (typeof fields.status === "string") {
+      allowedFields.status = fields.status;
+      if (fields.status === "completed") {
+        allowedFields.completed_at = new Date().toISOString();
+      } else if (fields.status === "active") {
+        allowedFields.completed_at = null;
+      }
+    }
+    if (typeof fields.progress === "number") allowedFields.progress = fields.progress;
+    if (typeof fields.target_date === "string" || fields.target_date === null)
+      allowedFields.target_date = fields.target_date;
+
+    allowedFields.updated_at = new Date().toISOString();
+
+    const { data, error } = await supabase
+      .from("goals")
+      .update(allowedFields)
+      .eq("id", goalId)
+      .eq("user_id", userId)
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Goal, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function logGoalProgress(
+  supabase: SupabaseClient,
+  userId: string,
+  goalId: string,
+  progress: number
+): Promise<QueryResult<Goal>> {
+  try {
+    const today = getToday();
+
+    const { data: goal, error: updateError } = await supabase
+      .from("goals")
+      .update({
+        progress,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", goalId)
+      .eq("user_id", userId)
+      .select()
+      .single();
+
+    if (updateError) return { data: null, error: updateError.message };
+
+    await supabase.from("goal_progress_logs").upsert(
+      { goal_id: goalId, user_id: userId, log_date: today, progress },
+      { onConflict: "goal_id,log_date" }
+    );
+
+    return { data: goal as Goal, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/habits.ts
+++ b/src/lib/mcp/queries/habits.ts
@@ -1,0 +1,275 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { getToday } from "@/lib/dates";
+
+export interface Habit {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  frequency: string | null;
+  target_days: number[] | null;
+  color: string | null;
+  archived: boolean;
+  sort_order: number;
+  goal_id: string | null;
+  created_at: string;
+}
+
+export interface HabitWithStatus extends Habit {
+  logged_today: boolean;
+}
+
+export interface HabitStats {
+  id: string;
+  name: string;
+  color: string | null;
+  streak: number;
+  completionRate: number;
+  recentLogs: string[];
+}
+
+export interface CreateHabitInput {
+  name: string;
+  description?: string;
+  frequency?: string;
+  target_days?: number[];
+  color?: string;
+  goal_id?: string;
+}
+
+function calculateStreak(logs: string[], targetDays: number[]): number {
+  const logSet = new Set(logs);
+  let streak = 0;
+  let started = false;
+  const checkDate = new Date();
+
+  for (let i = 0; i < 365; i++) {
+    const dateStr = checkDate.toISOString().split("T")[0];
+    const dayOfWeek = checkDate.getDay() === 0 ? 7 : checkDate.getDay();
+
+    if (!targetDays.includes(dayOfWeek)) {
+      checkDate.setDate(checkDate.getDate() - 1);
+      continue;
+    }
+
+    if (logSet.has(dateStr)) {
+      started = true;
+      streak++;
+      checkDate.setDate(checkDate.getDate() - 1);
+    } else if (started) {
+      break;
+    } else {
+      checkDate.setDate(checkDate.getDate() - 1);
+    }
+  }
+  return streak;
+}
+
+function getApplicableDays(startDate: Date, endDate: Date, targetDays: number[]): number {
+  let count = 0;
+  const cursor = new Date(startDate);
+
+  while (cursor <= endDate) {
+    const dayOfWeek = cursor.getDay() === 0 ? 7 : cursor.getDay();
+    if (targetDays.includes(dayOfWeek)) {
+      count++;
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  return count;
+}
+
+export async function getHabits(
+  supabase: SupabaseClient,
+  userId: string,
+  includeArchived = false
+): Promise<QueryResult<Habit[]>> {
+  try {
+    let query = supabase
+      .from("habits")
+      .select("*")
+      .eq("user_id", userId)
+      .order("sort_order", { ascending: true });
+
+    if (!includeArchived) {
+      query = query.eq("archived", false);
+    }
+
+    const { data, error } = await query;
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Habit[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function getHabitsWithTodayStatus(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<QueryResult<HabitWithStatus[]>> {
+  try {
+    const today = getToday();
+
+    const [habitsResult, logsResult] = await Promise.all([
+      supabase
+        .from("habits")
+        .select("*")
+        .eq("user_id", userId)
+        .eq("archived", false)
+        .order("sort_order", { ascending: true }),
+      supabase
+        .from("habit_logs")
+        .select("habit_id")
+        .eq("user_id", userId)
+        .eq("log_date", today),
+    ]);
+
+    if (habitsResult.error) return { data: null, error: habitsResult.error.message };
+    if (logsResult.error) return { data: null, error: logsResult.error.message };
+
+    const loggedIds = new Set((logsResult.data ?? []).map((l) => l.habit_id));
+    const habitsWithStatus: HabitWithStatus[] = (habitsResult.data as Habit[]).map((h) => ({
+      ...h,
+      logged_today: loggedIds.has(h.id),
+    }));
+
+    return { data: habitsWithStatus, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function createHabit(
+  supabase: SupabaseClient,
+  userId: string,
+  input: CreateHabitInput
+): Promise<QueryResult<Habit>> {
+  try {
+    const { data, error } = await supabase
+      .from("habits")
+      .insert({
+        user_id: userId,
+        name: input.name.trim(),
+        ...(input.description ? { description: input.description } : {}),
+        ...(input.frequency ? { frequency: input.frequency } : {}),
+        ...(input.target_days ? { target_days: input.target_days } : {}),
+        ...(input.color ? { color: input.color } : {}),
+        ...(input.goal_id !== undefined ? { goal_id: input.goal_id || null } : {}),
+      })
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Habit, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function toggleHabitLog(
+  supabase: SupabaseClient,
+  userId: string,
+  habitId: string,
+  date: string
+): Promise<QueryResult<{ logged: boolean }>> {
+  try {
+    // Verify the habit belongs to the user
+    const { error: habitError } = await supabase
+      .from("habits")
+      .select("id")
+      .eq("id", habitId)
+      .eq("user_id", userId)
+      .single();
+
+    if (habitError) return { data: null, error: "Habit not found" };
+
+    // Check if a log already exists for this habit + date
+    const { data: existingLog } = await supabase
+      .from("habit_logs")
+      .select("id")
+      .eq("habit_id", habitId)
+      .eq("log_date", date)
+      .single();
+
+    if (existingLog) {
+      const { error: deleteError } = await supabase
+        .from("habit_logs")
+        .delete()
+        .eq("id", existingLog.id);
+
+      if (deleteError) return { data: null, error: deleteError.message };
+      return { data: { logged: false }, error: null };
+    } else {
+      const { error: insertError } = await supabase
+        .from("habit_logs")
+        .insert({ habit_id: habitId, log_date: date, user_id: userId });
+
+      if (insertError) return { data: null, error: insertError.message };
+      return { data: { logged: true }, error: null };
+    }
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function getHabitStats(
+  supabase: SupabaseClient,
+  userId: string,
+  habitId: string,
+  days = 30
+): Promise<QueryResult<HabitStats>> {
+  try {
+    const safeDays = Math.max(1, days);
+    const today = new Date();
+    const startDate = new Date(today);
+    startDate.setDate(today.getDate() - (safeDays - 1));
+    const startDateStr = startDate.toISOString().split("T")[0];
+    const endDateStr = today.toISOString().split("T")[0];
+
+    const { data: habit, error: habitError } = await supabase
+      .from("habits")
+      .select("id, name, color, target_days")
+      .eq("id", habitId)
+      .eq("user_id", userId)
+      .single();
+
+    if (habitError) return { data: null, error: "Habit not found" };
+
+    const { data: logs, error: logsError } = await supabase
+      .from("habit_logs")
+      .select("log_date")
+      .eq("habit_id", habitId)
+      .gte("log_date", startDateStr)
+      .lte("log_date", endDateStr);
+
+    if (logsError) return { data: null, error: logsError.message };
+
+    const habitLogs = (logs ?? []).map((l) => l.log_date);
+    const targetDays: number[] =
+      Array.isArray(habit.target_days) && habit.target_days.length > 0
+        ? habit.target_days
+        : [1, 2, 3, 4, 5, 6, 7];
+
+    const streak = calculateStreak(habitLogs, targetDays);
+    const applicableDays = getApplicableDays(startDate, today, targetDays);
+    const completionRate = applicableDays > 0 ? habitLogs.length / applicableDays : 0;
+    const recentLogs = [...new Set(habitLogs)].sort().reverse();
+
+    return {
+      data: {
+        id: habit.id,
+        name: habit.name,
+        color: habit.color,
+        streak,
+        completionRate: Math.min(1, completionRate),
+        recentLogs,
+      },
+      error: null,
+    };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/journal.ts
+++ b/src/lib/mcp/queries/journal.ts
@@ -1,0 +1,109 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { getToday } from "@/lib/dates";
+
+export interface JournalEntry {
+  id: string;
+  user_id: string;
+  content: string;
+  entry_date: string;
+  mood: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateOrUpdateJournalInput {
+  content: string;
+  entry_date?: string;
+  mood?: number | null;
+}
+
+export async function getJournalEntry(
+  supabase: SupabaseClient,
+  userId: string,
+  date: string
+): Promise<QueryResult<JournalEntry | null>> {
+  try {
+    const { data, error } = await supabase
+      .from("journal_entries")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("entry_date", date)
+      .maybeSingle();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as JournalEntry | null, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function getRecentJournalEntries(
+  supabase: SupabaseClient,
+  userId: string,
+  limit = 7
+): Promise<QueryResult<JournalEntry[]>> {
+  try {
+    const { data, error } = await supabase
+      .from("journal_entries")
+      .select("*")
+      .eq("user_id", userId)
+      .order("entry_date", { ascending: false })
+      .limit(limit);
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as JournalEntry[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function searchJournal(
+  supabase: SupabaseClient,
+  userId: string,
+  query: string
+): Promise<QueryResult<JournalEntry[]>> {
+  try {
+    const { data, error } = await supabase
+      .from("journal_entries")
+      .select("*")
+      .eq("user_id", userId)
+      .textSearch("content", query, { type: "websearch" })
+      .order("entry_date", { ascending: false });
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as JournalEntry[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function createOrUpdateJournalEntry(
+  supabase: SupabaseClient,
+  userId: string,
+  input: CreateOrUpdateJournalInput
+): Promise<QueryResult<JournalEntry>> {
+  try {
+    const today = getToday();
+    const entryDate = input.entry_date || today;
+
+    const { data, error } = await supabase
+      .from("journal_entries")
+      .upsert(
+        {
+          user_id: userId,
+          content: input.content.trim(),
+          entry_date: entryDate,
+          mood: input.mood ?? null,
+        },
+        { onConflict: "user_id,entry_date" }
+      )
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as JournalEntry, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/reviews.ts
+++ b/src/lib/mcp/queries/reviews.ts
@@ -1,0 +1,87 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { startOfWeek, getToday } from "@/lib/dates";
+
+export interface WeeklyReview {
+  id: string;
+  user_id: string;
+  week_start: string;
+  content: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Get the most recent weekly review */
+export async function getLatestReview(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<QueryResult<WeeklyReview | null>> {
+  try {
+    const { data, error } = await supabase
+      .from("weekly_reviews")
+      .select("*")
+      .eq("user_id", userId)
+      .order("week_start", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as WeeklyReview | null, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+/** Get the weekly review for a specific week */
+export async function getReviewForWeek(
+  supabase: SupabaseClient,
+  userId: string,
+  weekStart: string
+): Promise<QueryResult<WeeklyReview | null>> {
+  try {
+    const { data, error } = await supabase
+      .from("weekly_reviews")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("week_start", weekStart)
+      .maybeSingle();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as WeeklyReview | null, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export interface SaveReviewInput {
+  week_start: string;
+  content: string;
+}
+
+/** Upsert a weekly review, tagged as source='mcp' */
+export async function saveReview(
+  supabase: SupabaseClient,
+  userId: string,
+  input: SaveReviewInput
+): Promise<QueryResult<WeeklyReview>> {
+  try {
+    const { data, error } = await supabase
+      .from("weekly_reviews")
+      .upsert(
+        {
+          user_id: userId,
+          week_start: input.week_start,
+          content: input.content,
+          source: "mcp",
+        },
+        { onConflict: "user_id,week_start" }
+      )
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as WeeklyReview, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/reviews.ts
+++ b/src/lib/mcp/queries/reviews.ts
@@ -1,6 +1,6 @@
 import { SupabaseClient } from "@supabase/supabase-js";
 import { QueryResult } from "@/lib/mcp/types";
-import { startOfWeek, getToday } from "@/lib/dates";
+
 
 export interface WeeklyReview {
   id: string;

--- a/src/lib/mcp/queries/spaces.ts
+++ b/src/lib/mcp/queries/spaces.ts
@@ -1,0 +1,103 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+
+export interface Space {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  status: "active" | "paused" | "completed";
+  deadline: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateSpaceInput {
+  name: string;
+  description?: string;
+  status?: string;
+}
+
+export interface UpdateSpaceFields {
+  name?: string;
+  description?: string | null;
+  status?: string;
+}
+
+export async function getSpaces(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<QueryResult<Space[]>> {
+  try {
+    const { data, error } = await supabase
+      .from("spaces")
+      .select("*")
+      .eq("user_id", userId)
+      .order("updated_at", { ascending: false });
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Space[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function createSpace(
+  supabase: SupabaseClient,
+  userId: string,
+  input: CreateSpaceInput
+): Promise<QueryResult<Space>> {
+  try {
+    const { data, error } = await supabase
+      .from("spaces")
+      .insert({
+        user_id: userId,
+        name: input.name,
+        description: input.description || null,
+        status: input.status || "active",
+      })
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Space, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function updateSpace(
+  supabase: SupabaseClient,
+  userId: string,
+  spaceId: string,
+  fields: UpdateSpaceFields
+): Promise<QueryResult<Space>> {
+  try {
+    const allowedFields: Record<string, unknown> = {};
+
+    if (typeof fields.name === "string") allowedFields.name = fields.name;
+    if (typeof fields.description === "string" || fields.description === null)
+      allowedFields.description = fields.description;
+    if (
+      typeof fields.status === "string" &&
+      ["active", "paused", "completed"].includes(fields.status)
+    ) {
+      allowedFields.status = fields.status;
+    }
+
+    allowedFields.updated_at = new Date().toISOString();
+
+    const { data, error } = await supabase
+      .from("spaces")
+      .update(allowedFields)
+      .eq("id", spaceId)
+      .eq("user_id", userId)
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Space, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/tasks.ts
+++ b/src/lib/mcp/queries/tasks.ts
@@ -1,0 +1,217 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+import { getToday } from "@/lib/dates";
+
+export interface Task {
+  id: string;
+  user_id: string;
+  title: string;
+  notes: string | null;
+  priority: string;
+  task_date: string;
+  space_id: string | null;
+  goal_id: string | null;
+  done: boolean;
+  done_at: string | null;
+  recurrence: unknown;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateTaskInput {
+  title: string;
+  notes?: string;
+  priority?: string;
+  task_date?: string;
+  space_id?: string;
+  goal_id?: string;
+  recurrence?: unknown;
+  sort_order?: number;
+}
+
+export interface UpdateTaskFields {
+  title?: string;
+  notes?: string | null;
+  priority?: string;
+  task_date?: string;
+  space_id?: string | null;
+  goal_id?: string | null;
+  done?: boolean;
+  sort_order?: number;
+}
+
+export async function getTasksForDate(
+  supabase: SupabaseClient,
+  userId: string,
+  date?: string
+): Promise<QueryResult<Task[]>> {
+  try {
+    const today = getToday();
+    const taskDate = date || today;
+
+    if (taskDate === today) {
+      const { data, error } = await supabase
+        .from("tasks")
+        .select("*")
+        .eq("user_id", userId)
+        .or(`task_date.eq.${taskDate},and(task_date.lt.${taskDate},done.eq.false)`)
+        .order("priority", { ascending: true })
+        .order("sort_order", { ascending: true });
+
+      if (error) return { data: null, error: error.message };
+      return { data: data as Task[], error: null };
+    }
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("task_date", taskDate)
+      .order("priority", { ascending: true })
+      .order("sort_order", { ascending: true });
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Task[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function getOverdueTasks(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<QueryResult<Task[]>> {
+  try {
+    const today = getToday();
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .select("*")
+      .eq("user_id", userId)
+      .lt("task_date", today)
+      .eq("done", false)
+      .order("priority", { ascending: true })
+      .order("sort_order", { ascending: true });
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Task[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function createTask(
+  supabase: SupabaseClient,
+  userId: string,
+  input: CreateTaskInput
+): Promise<QueryResult<Task>> {
+  try {
+    const today = getToday();
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .insert({
+        user_id: userId,
+        title: input.title,
+        notes: input.notes || null,
+        priority: typeof input.priority === "string" ? input.priority : "B1",
+        task_date: input.task_date || today,
+        space_id: input.space_id || null,
+        goal_id: input.goal_id || null,
+        recurrence: input.recurrence || null,
+        sort_order: typeof input.sort_order === "number" ? input.sort_order : 0,
+      })
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Task, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function updateTask(
+  supabase: SupabaseClient,
+  userId: string,
+  taskId: string,
+  fields: UpdateTaskFields
+): Promise<QueryResult<Task>> {
+  try {
+    const allowedFields: Record<string, unknown> = {};
+
+    if (typeof fields.title === "string") allowedFields.title = fields.title;
+    if (typeof fields.notes === "string" || fields.notes === null) allowedFields.notes = fields.notes;
+    if (typeof fields.priority === "string") allowedFields.priority = fields.priority;
+    if (typeof fields.task_date === "string") allowedFields.task_date = fields.task_date;
+    if (typeof fields.space_id === "string" || fields.space_id === null)
+      allowedFields.space_id = fields.space_id;
+    if (typeof fields.goal_id === "string" || fields.goal_id === null)
+      allowedFields.goal_id = fields.goal_id;
+    if (typeof fields.done === "boolean") {
+      allowedFields.done = fields.done;
+      allowedFields.done_at = fields.done ? new Date().toISOString() : null;
+    }
+    if (typeof fields.sort_order === "number") allowedFields.sort_order = fields.sort_order;
+
+    allowedFields.updated_at = new Date().toISOString();
+
+    const { data, error } = await supabase
+      .from("tasks")
+      .update(allowedFields)
+      .eq("id", taskId)
+      .eq("user_id", userId)
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Task, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function completeTask(
+  supabase: SupabaseClient,
+  userId: string,
+  taskId: string
+): Promise<QueryResult<Task>> {
+  try {
+    const { data, error } = await supabase
+      .from("tasks")
+      .update({
+        done: true,
+        done_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", taskId)
+      .eq("user_id", userId)
+      .select()
+      .single();
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as Task, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function deleteTask(
+  supabase: SupabaseClient,
+  userId: string,
+  taskId: string
+): Promise<QueryResult<{ success: boolean }>> {
+  try {
+    const { error } = await supabase
+      .from("tasks")
+      .delete()
+      .eq("id", taskId)
+      .eq("user_id", userId);
+
+    if (error) return { data: null, error: error.message };
+    return { data: { success: true }, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/queries/workouts.ts
+++ b/src/lib/mcp/queries/workouts.ts
@@ -1,0 +1,163 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { QueryResult } from "@/lib/mcp/types";
+
+export interface WorkoutLogExercise {
+  id: string;
+  log_id: string;
+  exercise_name: string;
+  exercise_type: string;
+  sort_order: number;
+  sets: unknown[];
+}
+
+export interface WorkoutLog {
+  id: string;
+  user_id: string;
+  name: string;
+  template_id: string | null;
+  log_date: string;
+  duration_minutes: number | null;
+  notes: string | null;
+  created_at: string;
+  workout_log_exercises: WorkoutLogExercise[];
+}
+
+export interface WorkoutExercise {
+  id: string;
+  template_id: string;
+  name: string;
+  exercise_type: string;
+  sort_order: number;
+  default_sets: number | null;
+  default_reps: number | null;
+  default_weight: number | null;
+  default_duration: number | null;
+  notes: string | null;
+}
+
+export interface WorkoutTemplate {
+  id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  created_at: string;
+  workout_exercises: WorkoutExercise[];
+}
+
+export interface LogWorkoutExerciseInput {
+  exercise_name: string;
+  exercise_type?: string;
+  sort_order?: number;
+  sets?: unknown[];
+}
+
+export interface LogWorkoutInput {
+  name: string;
+  log_date: string;
+  template_id?: string;
+  duration_minutes?: number;
+  notes?: string;
+  exercises?: LogWorkoutExerciseInput[];
+}
+
+export interface GetWorkoutLogsParams {
+  date?: string;
+  from?: string;
+  to?: string;
+}
+
+export async function getWorkoutLogs(
+  supabase: SupabaseClient,
+  userId: string,
+  params?: GetWorkoutLogsParams
+): Promise<QueryResult<WorkoutLog[]>> {
+  try {
+    let query = supabase
+      .from("workout_logs")
+      .select("*, workout_log_exercises(*)")
+      .eq("user_id", userId)
+      .order("log_date", { ascending: false });
+
+    if (params?.date) {
+      query = query.eq("log_date", params.date);
+    } else {
+      if (params?.from) query = query.gte("log_date", params.from);
+      if (params?.to) query = query.lte("log_date", params.to);
+    }
+
+    const { data, error } = await query;
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as WorkoutLog[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function getWorkoutTemplates(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<QueryResult<WorkoutTemplate[]>> {
+  try {
+    const { data, error } = await supabase
+      .from("workout_templates")
+      .select("*, workout_exercises(*)")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false });
+
+    if (error) return { data: null, error: error.message };
+    return { data: data as WorkoutTemplate[], error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}
+
+export async function logWorkout(
+  supabase: SupabaseClient,
+  userId: string,
+  input: LogWorkoutInput
+): Promise<QueryResult<WorkoutLog>> {
+  try {
+    const { data: log, error: logError } = await supabase
+      .from("workout_logs")
+      .insert({
+        user_id: userId,
+        name: input.name || "Workout",
+        template_id: input.template_id ?? null,
+        log_date: input.log_date,
+        duration_minutes: input.duration_minutes ?? null,
+        notes: input.notes ?? null,
+      })
+      .select()
+      .single();
+
+    if (logError) return { data: null, error: logError.message };
+
+    if (Array.isArray(input.exercises) && input.exercises.length > 0) {
+      const exerciseRows = input.exercises.map((ex) => ({
+        log_id: log.id,
+        exercise_name: ex.exercise_name,
+        exercise_type: ex.exercise_type || "strength",
+        sort_order: ex.sort_order ?? 0,
+        sets: ex.sets || [],
+      }));
+
+      const { error: exerciseError } = await supabase
+        .from("workout_log_exercises")
+        .insert(exerciseRows);
+
+      if (exerciseError) return { data: null, error: exerciseError.message };
+    }
+
+    const { data: result, error: fetchError } = await supabase
+      .from("workout_logs")
+      .select("*, workout_log_exercises(*)")
+      .eq("id", log.id)
+      .single();
+
+    if (fetchError) return { data: null, error: fetchError.message };
+    return { data: result as WorkoutLog, error: null };
+  } catch (err) {
+    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
+  }
+}

--- a/src/lib/mcp/rate-limit.ts
+++ b/src/lib/mcp/rate-limit.ts
@@ -1,0 +1,56 @@
+import { UserPlan } from "./types";
+
+const DAY_MS = 86_400_000;
+
+const LIMITS: Record<UserPlan, number> = {
+  free: 500,
+  active: 10_000,
+  canceled: 500,
+  expired: 500,
+};
+
+// In-memory daily request counts: userId -> timestamp[]
+const requestLog = new Map<string, number[]>();
+
+/**
+ * Check MCP daily rate limit. Returns null if allowed,
+ * or a Retry-After value in seconds if rate limited.
+ */
+export function checkMcpRateLimit(userId: string, plan: UserPlan): number | null {
+  const now = Date.now();
+  const limit = LIMITS[plan];
+  const cutoff = now - DAY_MS;
+
+  let timestamps = requestLog.get(userId);
+  if (!timestamps) {
+    timestamps = [];
+    requestLog.set(userId, timestamps);
+  }
+
+  // Prune old entries
+  timestamps = timestamps.filter((t) => t > cutoff);
+  requestLog.set(userId, timestamps);
+
+  if (timestamps.length >= limit) {
+    // Earliest timestamp that will expire
+    const oldest = timestamps[0];
+    const retryAfter = Math.ceil((oldest + DAY_MS - now) / 1000);
+    return retryAfter;
+  }
+
+  timestamps.push(now);
+
+  // Purge stale users periodically
+  if (requestLog.size > 500) {
+    for (const [key, ts] of requestLog) {
+      const filtered = ts.filter((t) => t > cutoff);
+      if (filtered.length === 0) {
+        requestLog.delete(key);
+      } else {
+        requestLog.set(key, filtered);
+      }
+    }
+  }
+
+  return null;
+}

--- a/src/lib/mcp/resources/briefings.ts
+++ b/src/lib/mcp/resources/briefings.ts
@@ -1,0 +1,37 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getTodayBriefing } from "@/lib/mcp/queries/briefings";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerBriefingResources(server: McpServer) {
+  // --- briefing-today ---
+  server.resource(
+    "briefing-today",
+    "dailyagent://briefing/today",
+    { description: "Today's AI-generated daily briefing, if one has been generated" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("briefing:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: briefing:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getTodayBriefing(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? null),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/calendar.ts
+++ b/src/lib/mcp/resources/calendar.ts
@@ -1,0 +1,68 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getDaySummary, getWeekSummary } from "@/lib/mcp/queries/calendar";
+import { getToday } from "@/lib/dates";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerCalendarResources(server: McpServer) {
+  // --- calendar-today ---
+  server.resource(
+    "calendar-today",
+    "dailyagent://calendar/today",
+    { description: "Detailed view of today: tasks, habits, journal, workouts, and focus sessions" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("calendar:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: calendar:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getDaySummary(supabase, auth.userId, getToday());
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? null),
+          },
+        ],
+      };
+    }
+  );
+
+  // --- calendar-week ---
+  server.resource(
+    "calendar-week",
+    "dailyagent://calendar/week",
+    { description: "Aggregated summary for the current week (Monday–Sunday)" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("calendar:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: calendar:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getWeekSummary(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? null),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/dashboard.ts
+++ b/src/lib/mcp/resources/dashboard.ts
@@ -1,0 +1,32 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getDashboardSnapshot } from "@/lib/mcp/queries/dashboard";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerDashboardResources(server: McpServer) {
+  // --- dashboard ---
+  server.resource(
+    "dashboard",
+    "dailyagent://dashboard",
+    { description: "Today's aggregated productivity snapshot: tasks, habits, journal, workouts, focus, and goals" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      // Dashboard is accessible to any authenticated user — no specific scope required
+      const supabase = getServiceClient();
+      const result = await getDashboardSnapshot(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? null),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/focus.ts
+++ b/src/lib/mcp/resources/focus.ts
@@ -1,0 +1,37 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getTodayFocusStats } from "@/lib/mcp/queries/focus";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerFocusResources(server: McpServer) {
+  // --- focus-today ---
+  server.resource(
+    "focus-today",
+    "dailyagent://focus/today",
+    { description: "Today's focus session totals: total minutes and session count" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("focus:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: focus:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getTodayFocusStats(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? { totalMinutes: 0, sessionCount: 0 }),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/goals.ts
+++ b/src/lib/mcp/resources/goals.ts
@@ -1,0 +1,37 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getGoals } from "@/lib/mcp/queries/goals";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerGoalResources(server: McpServer) {
+  // --- goals-active ---
+  server.resource(
+    "goals-active",
+    "dailyagent://goals/active",
+    { description: "All active goals, ordered by sort order and creation date" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("goals:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: goals:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getGoals(supabase, auth.userId, "active");
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? []),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/habits.ts
+++ b/src/lib/mcp/resources/habits.ts
@@ -1,0 +1,93 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import {
+  getHabitsWithTodayStatus,
+  getHabits,
+  getHabitStats,
+  type Habit,
+} from "@/lib/mcp/queries/habits";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerHabitResources(server: McpServer) {
+  // --- habits-today ---
+  server.resource(
+    "habits-today",
+    "dailyagent://habits/today",
+    { description: "All active habits with today's completion status" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("habits:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: habits:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getHabitsWithTodayStatus(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? []),
+          },
+        ],
+      };
+    }
+  );
+
+  // --- habits-streaks ---
+  server.resource(
+    "habits-streaks",
+    "dailyagent://habits/streaks",
+    { description: "Streak and completion rate stats for all active habits (last 30 days)" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("habits:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: habits:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const habitsResult = await getHabits(supabase, auth.userId);
+      if (!habitsResult.data) {
+        return {
+          contents: [
+            {
+              uri: uri.href,
+              mimeType: "application/json",
+              text: JSON.stringify([]),
+            },
+          ],
+        };
+      }
+
+      const statsResults = await Promise.all(
+        habitsResult.data.map((habit: Habit) =>
+          getHabitStats(supabase, auth.userId, habit.id)
+        )
+      );
+
+      const stats = statsResults
+        .filter((r) => r.data !== null)
+        .map((r) => r.data);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(stats),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/journal.ts
+++ b/src/lib/mcp/resources/journal.ts
@@ -1,0 +1,68 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getJournalEntry, getRecentJournalEntries } from "@/lib/mcp/queries/journal";
+import { getToday } from "@/lib/dates";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerJournalResources(server: McpServer) {
+  // --- journal-today ---
+  server.resource(
+    "journal-today",
+    "dailyagent://journal/today",
+    { description: "Today's journal entry, or null if none has been written" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("journal:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: journal:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getJournalEntry(supabase, auth.userId, getToday());
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? null),
+          },
+        ],
+      };
+    }
+  );
+
+  // --- journal-recent ---
+  server.resource(
+    "journal-recent",
+    "dailyagent://journal/recent",
+    { description: "The 7 most recent journal entries, newest first" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("journal:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: journal:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getRecentJournalEntries(supabase, auth.userId, 7);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? []),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/reviews.ts
+++ b/src/lib/mcp/resources/reviews.ts
@@ -1,0 +1,37 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getLatestReview } from "@/lib/mcp/queries/reviews";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerReviewResources(server: McpServer) {
+  // --- review-latest ---
+  server.resource(
+    "review-latest",
+    "dailyagent://review/latest",
+    { description: "The most recent weekly review, or null if none exists" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("review:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: review:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getLatestReview(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? null),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/spaces.ts
+++ b/src/lib/mcp/resources/spaces.ts
@@ -1,0 +1,37 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getSpaces } from "@/lib/mcp/queries/spaces";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerSpaceResources(server: McpServer) {
+  // --- spaces-list ---
+  server.resource(
+    "spaces-list",
+    "dailyagent://spaces",
+    { description: "All spaces (projects), ordered by last updated" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("spaces:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: spaces:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getSpaces(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? []),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/tasks.ts
+++ b/src/lib/mcp/resources/tasks.ts
@@ -1,0 +1,67 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getTasksForDate, getOverdueTasks } from "@/lib/mcp/queries/tasks";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerTaskResources(server: McpServer) {
+  // --- tasks-today ---
+  server.resource(
+    "tasks-today",
+    "dailyagent://tasks/today",
+    { description: "Today's tasks, including any incomplete tasks from previous days" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("tasks:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: tasks:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getTasksForDate(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? []),
+          },
+        ],
+      };
+    }
+  );
+
+  // --- tasks-overdue ---
+  server.resource(
+    "tasks-overdue",
+    "dailyagent://tasks/overdue",
+    { description: "Incomplete tasks with a date before today" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("tasks:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: tasks:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const result = await getOverdueTasks(supabase, auth.userId);
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? []),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/resources/workouts.ts
+++ b/src/lib/mcp/resources/workouts.ts
@@ -1,0 +1,40 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getWorkoutLogs } from "@/lib/mcp/queries/workouts";
+import { getToday, addDays } from "@/lib/dates";
+import type { Extra } from "@/lib/mcp/tools/helpers";
+
+export function registerWorkoutResources(server: McpServer) {
+  // --- workouts-recent ---
+  server.resource(
+    "workouts-recent",
+    "dailyagent://workouts/recent",
+    { description: "Workout logs from the last 7 days, newest first" },
+    async (uri, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return { contents: [] };
+
+      if (!auth.scopes.includes("workouts:read")) {
+        return {
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: workouts:read" }],
+        };
+      }
+
+      const supabase = getServiceClient();
+      const today = getToday();
+      const from = addDays(today, -7);
+      const result = await getWorkoutLogs(supabase, auth.userId, { from, to: today });
+
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: "application/json",
+            text: JSON.stringify(result.data ?? []),
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/lib/mcp/server.ts
+++ b/src/lib/mcp/server.ts
@@ -1,0 +1,70 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTaskResources } from "./resources/tasks";
+import { registerHabitResources } from "./resources/habits";
+import { registerJournalResources } from "./resources/journal";
+import { registerWorkoutResources } from "./resources/workouts";
+import { registerFocusResources } from "./resources/focus";
+import { registerGoalResources } from "./resources/goals";
+import { registerSpaceResources } from "./resources/spaces";
+import { registerCalendarResources } from "./resources/calendar";
+import { registerDashboardResources } from "./resources/dashboard";
+import { registerBriefingResources } from "./resources/briefings";
+import { registerReviewResources } from "./resources/reviews";
+import { registerTaskTools } from "./tools/tasks";
+import { registerHabitTools } from "./tools/habits";
+import { registerJournalTools } from "./tools/journal";
+import { registerWorkoutTools } from "./tools/workouts";
+import { registerFocusTools } from "./tools/focus";
+import { registerGoalTools } from "./tools/goals";
+import { registerSpaceTools } from "./tools/spaces";
+import { registerCalendarTools } from "./tools/calendar";
+import { registerBriefingTools } from "./tools/briefings";
+import { registerReviewTools } from "./tools/reviews";
+import { registerPrompts } from "./prompts";
+
+/** Create and configure the MCP server with all tools, resources, and prompts */
+export function createMcpServer(): McpServer {
+  const server = new McpServer(
+    {
+      name: "Daily Agent",
+      version: "1.0.0",
+    },
+    {
+      capabilities: {
+        resources: {},
+        tools: {},
+        prompts: {},
+      },
+    }
+  );
+
+  // Register all resources
+  registerTaskResources(server);
+  registerHabitResources(server);
+  registerJournalResources(server);
+  registerWorkoutResources(server);
+  registerFocusResources(server);
+  registerGoalResources(server);
+  registerSpaceResources(server);
+  registerCalendarResources(server);
+  registerDashboardResources(server);
+  registerBriefingResources(server);
+  registerReviewResources(server);
+
+  // Register all tools
+  registerTaskTools(server);
+  registerHabitTools(server);
+  registerJournalTools(server);
+  registerWorkoutTools(server);
+  registerFocusTools(server);
+  registerGoalTools(server);
+  registerSpaceTools(server);
+  registerCalendarTools(server);
+  registerBriefingTools(server);
+  registerReviewTools(server);
+
+  // Register prompts
+  registerPrompts(server);
+
+  return server;
+}

--- a/src/lib/mcp/supabase.ts
+++ b/src/lib/mcp/supabase.ts
@@ -1,0 +1,18 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { Database } from "@/types/database";
+
+let _serviceClient: SupabaseClient<Database> | null = null;
+
+/** Service-role Supabase client for MCP requests (bypasses RLS) */
+export function getServiceClient(): SupabaseClient<Database> {
+  if (_serviceClient) return _serviceClient;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+  }
+
+  _serviceClient = createClient<Database>(url, key);
+  return _serviceClient;
+}

--- a/src/lib/mcp/tools/__tests__/helpers.test.ts
+++ b/src/lib/mcp/tools/__tests__/helpers.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from "vitest";
+import { getAuth, checkScope, textResult, errorResult, Extra } from "@/lib/mcp/tools/helpers";
+
+// ---------------------------------------------------------------------------
+// Helpers to build the Extra-shaped objects the handlers receive
+// ---------------------------------------------------------------------------
+
+function makeExtra(overrides: Record<string, unknown> = {}): Extra {
+  return overrides as unknown as Extra;
+}
+
+function makeExtraWithAuth(userId: string, scopes: string[], plan = "free"): Extra {
+  return makeExtra({
+    authInfo: {
+      extra: { userId, plan },
+      scopes,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+describe("getAuth", () => {
+  it("extracts userId, scopes, and plan from extra object", () => {
+    const extra = makeExtraWithAuth("user-abc", ["tasks:read", "tasks:write"], "active");
+    const auth = getAuth(extra);
+
+    expect(auth).not.toBeNull();
+    expect(auth!.userId).toBe("user-abc");
+    expect(auth!.scopes).toEqual(["tasks:read", "tasks:write"]);
+    expect(auth!.plan).toBe("active");
+  });
+
+  it("returns null when authInfo is missing", () => {
+    const extra = makeExtra({});
+    expect(getAuth(extra)).toBeNull();
+  });
+
+  it("returns null when userId is missing from authInfo.extra", () => {
+    const extra = makeExtra({
+      authInfo: {
+        extra: { plan: "free" }, // no userId
+        scopes: [],
+      },
+    });
+    expect(getAuth(extra)).toBeNull();
+  });
+
+  it("defaults scopes to empty array when not provided", () => {
+    const extra = makeExtra({
+      authInfo: {
+        extra: { userId: "user-xyz" },
+        // no scopes field
+      },
+    });
+    const auth = getAuth(extra);
+    expect(auth).not.toBeNull();
+    expect(auth!.scopes).toEqual([]);
+  });
+
+  it('defaults plan to "free" when not provided', () => {
+    const extra = makeExtra({
+      authInfo: {
+        extra: { userId: "user-xyz" },
+        scopes: [],
+      },
+    });
+    const auth = getAuth(extra);
+    expect(auth).not.toBeNull();
+    expect(auth!.plan).toBe("free");
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("checkScope", () => {
+  it("returns null when the required scope is present", () => {
+    expect(checkScope(["tasks:read", "tasks:write"], "tasks:read")).toBeNull();
+  });
+
+  it("returns an error message string when the required scope is missing", () => {
+    const result = checkScope(["tasks:read"], "tasks:write");
+    expect(typeof result).toBe("string");
+    expect(result).toContain("tasks:write");
+  });
+
+  it("returns an error message when scopes array is empty", () => {
+    const result = checkScope([], "habits:read");
+    expect(result).not.toBeNull();
+    expect(result).toContain("habits:read");
+  });
+
+  it("is case-sensitive when matching scopes", () => {
+    expect(checkScope(["Tasks:Read"], "tasks:read")).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("textResult", () => {
+  it("wraps data in MCP content format with type text", () => {
+    const result = textResult({ id: 1, title: "Test task" });
+    expect(result).toHaveProperty("content");
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+  });
+
+  it("serializes the data as JSON in the text field", () => {
+    const data = { id: "abc", done: false };
+    const result = textResult(data);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual(data);
+  });
+
+  it("handles arrays", () => {
+    const data = [{ id: 1 }, { id: 2 }];
+    const result = textResult(data);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toEqual(data);
+  });
+
+  it("handles null", () => {
+    const result = textResult(null);
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("errorResult", () => {
+  it("wraps the message in MCP content format", () => {
+    const result = errorResult("Something went wrong");
+    expect(result).toHaveProperty("content");
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toBe("Something went wrong");
+  });
+
+  it("sets isError to true", () => {
+    const result = errorResult("error");
+    expect(result.isError).toBe(true);
+  });
+
+  it("preserves the full error message string", () => {
+    const msg = "Insufficient scope: tasks:write";
+    const result = errorResult(msg);
+    expect(result.content[0].text).toBe(msg);
+  });
+});

--- a/src/lib/mcp/tools/briefings.ts
+++ b/src/lib/mcp/tools/briefings.ts
@@ -1,0 +1,50 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getTodayBriefing(userId: string) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data, error } = await supabase
+    .from("daily_briefings")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("briefing_date", today)
+    .single();
+
+  return { data, error: error?.code === "PGRST116" ? null : (error?.message ?? null) };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerBriefingTools(server: McpServer) {
+  // --- get_daily_briefing (READ) ---
+  server.tool(
+    "get_daily_briefing",
+    "Get the AI-generated daily briefing for today",
+    {},
+    async (_args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "briefing:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getTodayBriefing(auth.userId);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      if (!result.data) {
+        return textResult({ message: "No briefing available for today. Generate one from the Daily Agent dashboard." });
+      }
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/tools/calendar.ts
+++ b/src/lib/mcp/tools/calendar.ts
@@ -1,0 +1,225 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getDaySummary(userId: string, date: string) {
+  const supabase = getServiceClient();
+
+  const [tasksRes, habitsRes, journalRes, workoutsRes, focusRes] = await Promise.all([
+    // Tasks for the day (including rolled-over incomplete)
+    supabase
+      .from("tasks")
+      .select("id, title, priority, done, task_date")
+      .eq("user_id", userId)
+      .or(`task_date.eq.${date},and(task_date.lt.${date},done.eq.false)`)
+      .order("priority", { ascending: true }),
+
+    // Habit completions for the day
+    supabase
+      .from("habits")
+      .select("id, name, habit_logs!inner(log_date)")
+      .eq("user_id", userId)
+      .eq("habit_logs.log_date", date),
+
+    // Journal entry for the day
+    supabase
+      .from("journal_entries")
+      .select("id, content, mood, entry_date")
+      .eq("user_id", userId)
+      .eq("entry_date", date)
+      .single(),
+
+    // Workouts for the day
+    supabase
+      .from("workout_logs")
+      .select("id, name, duration_minutes, log_date")
+      .eq("user_id", userId)
+      .eq("log_date", date),
+
+    // Focus sessions for the day
+    supabase
+      .from("focus_sessions")
+      .select("id, duration_minutes, completed_at, started_at")
+      .eq("user_id", userId)
+      .gte("started_at", `${date}T00:00:00.000Z`)
+      .lte("started_at", `${date}T23:59:59.999Z`),
+  ]);
+
+  const tasks = tasksRes.data ?? [];
+  const completedTasks = tasks.filter((t) => t.done);
+
+  const focusSessions = focusRes.data ?? [];
+  const completedFocus = focusSessions.filter((s) => s.completed_at != null);
+  const totalFocusMinutes = completedFocus.reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+
+  return {
+    data: {
+      date,
+      tasks: {
+        total: tasks.length,
+        completed: completedTasks.length,
+        items: tasks,
+      },
+      habits: {
+        completed: habitsRes.data?.length ?? 0,
+        items: habitsRes.data ?? [],
+      },
+      journal: journalRes.data ?? null,
+      workouts: workoutsRes.data ?? [],
+      focus: {
+        totalMinutes: totalFocusMinutes,
+        sessionCount: completedFocus.length,
+      },
+    },
+    error: null,
+  };
+}
+
+async function getWeekSummary(userId: string, weekStart: string) {
+  const supabase = getServiceClient();
+
+  // Calculate week end (6 days after start)
+  const startDate = new Date(weekStart);
+  const endDate = new Date(startDate);
+  endDate.setDate(startDate.getDate() + 6);
+  const weekEnd = endDate.toISOString().split("T")[0];
+
+  const [tasksRes, habitLogsRes, workoutsRes, focusRes, journalRes] = await Promise.all([
+    supabase
+      .from("tasks")
+      .select("id, title, priority, done, task_date")
+      .eq("user_id", userId)
+      .gte("task_date", weekStart)
+      .lte("task_date", weekEnd),
+
+    supabase
+      .from("habit_logs")
+      .select("habit_id, log_date, habits!inner(name, user_id)")
+      .gte("log_date", weekStart)
+      .lte("log_date", weekEnd)
+      .eq("habits.user_id", userId),
+
+    supabase
+      .from("workout_logs")
+      .select("id, name, duration_minutes, log_date")
+      .eq("user_id", userId)
+      .gte("log_date", weekStart)
+      .lte("log_date", weekEnd),
+
+    supabase
+      .from("focus_sessions")
+      .select("id, duration_minutes, completed_at, started_at")
+      .eq("user_id", userId)
+      .gte("started_at", `${weekStart}T00:00:00.000Z`)
+      .lte("started_at", `${weekEnd}T23:59:59.999Z`),
+
+    supabase
+      .from("journal_entries")
+      .select("id, entry_date, mood")
+      .eq("user_id", userId)
+      .gte("entry_date", weekStart)
+      .lte("entry_date", weekEnd),
+  ]);
+
+  const tasks = tasksRes.data ?? [];
+  const completedTasks = tasks.filter((t) => t.done);
+
+  const focusSessions = focusRes.data ?? [];
+  const completedFocus = focusSessions.filter((s) => s.completed_at != null);
+  const totalFocusMinutes = completedFocus.reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+
+  const moods = (journalRes.data ?? []).filter((j) => j.mood != null).map((j) => j.mood as number);
+  const avgMood = moods.length > 0 ? moods.reduce((a, b) => a + b, 0) / moods.length : null;
+
+  return {
+    data: {
+      weekStart,
+      weekEnd,
+      tasks: {
+        total: tasks.length,
+        completed: completedTasks.length,
+        completionRate: tasks.length > 0 ? Math.round((completedTasks.length / tasks.length) * 100) : 0,
+      },
+      habits: {
+        totalCompletions: habitLogsRes.data?.length ?? 0,
+      },
+      workouts: {
+        count: workoutsRes.data?.length ?? 0,
+        totalMinutes: (workoutsRes.data ?? []).reduce((sum, w) => sum + (w.duration_minutes ?? 0), 0),
+      },
+      focus: {
+        totalMinutes: totalFocusMinutes,
+        sessionCount: completedFocus.length,
+      },
+      journal: {
+        entriesWritten: journalRes.data?.length ?? 0,
+        averageMood: avgMood,
+      },
+    },
+    error: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerCalendarTools(server: McpServer) {
+  // --- get_day_summary (READ) ---
+  server.tool(
+    "get_day_summary",
+    "Get a comprehensive summary of a day including tasks, habits, journal, workouts, and focus sessions",
+    {
+      date: z.string().optional().describe("Date in YYYY-MM-DD format (defaults to today)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "calendar:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const date = args.date ?? new Date().toISOString().split("T")[0];
+      const result = await getDaySummary(auth.userId, date);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- get_week_summary (READ) ---
+  server.tool(
+    "get_week_summary",
+    "Get an aggregated summary of a full week including task completion, habits, workouts, focus time, and mood",
+    {
+      week_start: z.string().optional().describe("Week start date in YYYY-MM-DD format (defaults to this Monday)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "calendar:read");
+      if (scopeError) return errorResult(scopeError);
+
+      // Default to the most recent Monday
+      let weekStart = args.week_start;
+      if (!weekStart) {
+        const now = new Date();
+        const day = now.getDay();
+        const diff = (day === 0 ? -6 : 1 - day);
+        now.setDate(now.getDate() + diff);
+        weekStart = now.toISOString().split("T")[0];
+      }
+
+      const result = await getWeekSummary(auth.userId, weekStart);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/tools/focus.ts
+++ b/src/lib/mcp/tools/focus.ts
@@ -1,0 +1,188 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, PAID_PLAN_REQUIRED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getFocusSessions(userId: string, from?: string, to?: string) {
+  const supabase = getServiceClient();
+
+  let query = supabase
+    .from("focus_sessions")
+    .select("*")
+    .eq("user_id", userId)
+    .order("started_at", { ascending: false });
+
+  if (from) query = query.gte("started_at", `${from}T00:00:00.000Z`);
+  if (to) query = query.lte("started_at", `${to}T23:59:59.999Z`);
+  if (!from && !to) query = query.limit(30);
+
+  const { data, error } = await query;
+  return { data, error: error?.message ?? null };
+}
+
+async function getTodayFocusStats(userId: string) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data: sessions, error } = await supabase
+    .from("focus_sessions")
+    .select("*")
+    .eq("user_id", userId)
+    .gte("started_at", `${today}T00:00:00.000Z`)
+    .lte("started_at", `${today}T23:59:59.999Z`);
+
+  if (error) return { data: null, error: error.message };
+
+  const completed = sessions?.filter((s) => s.completed_at != null) ?? [];
+  const totalMinutes = completed.reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+
+  return {
+    data: {
+      date: today,
+      totalSessions: sessions?.length ?? 0,
+      completedSessions: completed.length,
+      totalFocusMinutes: totalMinutes,
+      sessions,
+    },
+    error: null,
+  };
+}
+
+async function startFocusSession(
+  userId: string,
+  args: {
+    duration_minutes: number;
+    task_id?: string;
+    break_minutes?: number;
+  }
+) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("focus_sessions")
+    .insert({
+      user_id: userId,
+      duration_minutes: args.duration_minutes,
+      task_id: args.task_id ?? null,
+      break_minutes: args.break_minutes ?? 5,
+      started_at: new Date().toISOString(),
+      completed_at: null,
+    })
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+async function completeFocusSession(userId: string, sessionId: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("focus_sessions")
+    .update({ completed_at: new Date().toISOString() })
+    .eq("id", sessionId)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerFocusTools(server: McpServer) {
+  // --- get_focus_sessions (READ) ---
+  server.tool(
+    "get_focus_sessions",
+    "Get focus/Pomodoro sessions, optionally filtered by date range",
+    {
+      from: z.string().optional().describe("Start date in YYYY-MM-DD format"),
+      to: z.string().optional().describe("End date in YYYY-MM-DD format"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "focus:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getFocusSessions(auth.userId, args.from, args.to);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- get_focus_stats (READ) ---
+  server.tool(
+    "get_focus_stats",
+    "Get today's focus session statistics including total minutes and session count",
+    {},
+    async (_args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "focus:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getTodayFocusStats(auth.userId);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- start_focus_session (WRITE) ---
+  server.tool(
+    "start_focus_session",
+    "Start a new focus/Pomodoro session",
+    {
+      duration_minutes: z.number().describe("Focus session duration in minutes (e.g. 25)"),
+      task_id: z.string().optional().describe("Task ID to associate this session with"),
+      break_minutes: z.number().optional().describe("Break duration in minutes (default: 5)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "focus:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await startFocusSession(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- complete_focus_session (WRITE) ---
+  server.tool(
+    "complete_focus_session",
+    "Mark a focus session as complete",
+    {
+      session_id: z.string().describe("Focus session ID to complete"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "focus:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await completeFocusSession(auth.userId, args.session_id);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/tools/goals.ts
+++ b/src/lib/mcp/tools/goals.ts
@@ -1,0 +1,201 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, PAID_PLAN_REQUIRED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getGoals(userId: string, status?: string) {
+  const supabase = getServiceClient();
+
+  let query = supabase
+    .from("goals")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  if (status) query = query.eq("status", status as "active" | "completed" | "abandoned");
+
+  const { data, error } = await query;
+  return { data, error: error?.message ?? null };
+}
+
+async function createGoal(
+  userId: string,
+  args: {
+    title: string;
+    description?: string;
+    category?: string;
+    target_date?: string;
+  }
+) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("goals")
+    .insert({
+      user_id: userId,
+      title: args.title,
+      description: args.description ?? null,
+      ...(args.category
+        ? { category: args.category as "health" | "career" | "personal" | "financial" | "learning" | "relationships" | "other" }
+        : {}),
+      target_date: args.target_date ?? null,
+      status: "active" as const,
+      progress: 0,
+    })
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+async function updateGoal(
+  userId: string,
+  args: {
+    goal_id: string;
+    title?: string;
+    description?: string;
+    status?: string;
+    progress?: number;
+  }
+) {
+  const supabase = getServiceClient();
+
+  const updates: Record<string, unknown> = {};
+  if (args.title !== undefined) updates.title = args.title;
+  if (args.description !== undefined) updates.description = args.description;
+  if (args.status !== undefined) updates.status = args.status;
+  if (args.progress !== undefined) updates.progress = args.progress;
+
+  const { data, error } = await supabase
+    .from("goals")
+    .update(updates)
+    .eq("id", args.goal_id)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+async function logGoalProgress(userId: string, goalId: string, progress: number) {
+  const supabase = getServiceClient();
+
+  // Verify ownership then update progress
+  const { data, error } = await supabase
+    .from("goals")
+    .update({ progress })
+    .eq("id", goalId)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerGoalTools(server: McpServer) {
+  // --- list_goals (READ) ---
+  server.tool(
+    "list_goals",
+    "List goals, optionally filtered by status",
+    {
+      status: z.string().optional().describe("Filter by status: active, completed, paused, or abandoned"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "goals:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getGoals(auth.userId, args.status);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- create_goal (WRITE) ---
+  server.tool(
+    "create_goal",
+    "Create a new goal",
+    {
+      title: z.string().describe("Goal title"),
+      description: z.string().optional().describe("Detailed description of the goal"),
+      category: z.string().optional().describe("Goal category (e.g. health, career, personal)"),
+      target_date: z.string().optional().describe("Target completion date in YYYY-MM-DD format"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "goals:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await createGoal(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- update_goal (WRITE) ---
+  server.tool(
+    "update_goal",
+    "Update an existing goal's details or status",
+    {
+      goal_id: z.string().describe("Goal ID"),
+      title: z.string().optional().describe("New title"),
+      description: z.string().optional().describe("New description"),
+      status: z.string().optional().describe("New status: active, completed, paused, or abandoned"),
+      progress: z.number().min(0).max(100).optional().describe("Progress percentage (0-100)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "goals:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await updateGoal(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- log_goal_progress (WRITE) ---
+  server.tool(
+    "log_goal_progress",
+    "Update the progress percentage for a goal",
+    {
+      goal_id: z.string().describe("Goal ID"),
+      progress: z.number().min(0).max(100).describe("Progress percentage (0-100)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "goals:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await logGoalProgress(auth.userId, args.goal_id, args.progress);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/tools/habits.ts
+++ b/src/lib/mcp/tools/habits.ts
@@ -1,0 +1,243 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, PAID_PLAN_REQUIRED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getHabits(userId: string, includeArchived = false) {
+  const supabase = getServiceClient();
+
+  let query = supabase
+    .from("habits")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: true });
+
+  if (!includeArchived) {
+    query = query.eq("archived", false);
+  }
+
+  const { data, error } = await query;
+  return { data, error: error?.message ?? null };
+}
+
+async function getHabitStats(userId: string, habitId: string, days = 30) {
+  const supabase = getServiceClient();
+
+  // Verify ownership
+  const { data: habit, error: habitError } = await supabase
+    .from("habits")
+    .select("*")
+    .eq("id", habitId)
+    .eq("user_id", userId)
+    .single();
+
+  if (habitError || !habit) {
+    return { data: null, error: "Habit not found" };
+  }
+
+  const fromDate = new Date();
+  fromDate.setDate(fromDate.getDate() - days);
+  const fromStr = fromDate.toISOString().split("T")[0];
+
+  const { data: logs, error: logsError } = await supabase
+    .from("habit_logs")
+    .select("*")
+    .eq("habit_id", habitId)
+    .gte("log_date", fromStr)
+    .order("log_date", { ascending: false });
+
+  if (logsError) return { data: null, error: logsError.message };
+
+  const completedDays = logs?.length ?? 0;
+  const completionRate = days > 0 ? Math.round((completedDays / days) * 100) : 0;
+
+  return {
+    data: {
+      habit,
+      logs,
+      stats: {
+        completedDays,
+        totalDays: days,
+        completionRate,
+      },
+    },
+    error: null,
+  };
+}
+
+async function createHabit(
+  userId: string,
+  args: {
+    name: string;
+    description?: string;
+    frequency?: string;
+    target_days?: number[];
+    color?: string;
+  }
+) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("habits")
+    .insert({
+      user_id: userId,
+      name: args.name,
+      description: args.description ?? null,
+      frequency: (args.frequency === "weekly" ? "weekly" : "daily") satisfies "daily" | "weekly",
+      target_days: args.target_days ?? [0, 1, 2, 3, 4, 5, 6],
+      archived: false,
+    })
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+async function toggleHabitLog(userId: string, habitId: string, date?: string) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+  const logDate = date ?? today;
+
+  // Verify ownership
+  const { data: habit, error: habitError } = await supabase
+    .from("habits")
+    .select("id")
+    .eq("id", habitId)
+    .eq("user_id", userId)
+    .single();
+
+  if (habitError || !habit) {
+    return { data: null, error: "Habit not found" };
+  }
+
+  // Check if log exists
+  const { data: existing } = await supabase
+    .from("habit_logs")
+    .select("id")
+    .eq("habit_id", habitId)
+    .eq("log_date", logDate)
+    .single();
+
+  if (existing) {
+    // Toggle off: delete the log
+    const { error } = await supabase
+      .from("habit_logs")
+      .delete()
+      .eq("id", existing.id);
+
+    return { data: { toggled: false, date: logDate }, error: error?.message ?? null };
+  } else {
+    // Toggle on: insert a log
+    const { data, error } = await supabase
+      .from("habit_logs")
+      .insert({ habit_id: habitId, user_id: userId, log_date: logDate })
+      .select()
+      .single();
+
+    return { data: { toggled: true, date: logDate, log: data }, error: error?.message ?? null };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerHabitTools(server: McpServer) {
+  // --- list_habits (READ) ---
+  server.tool(
+    "list_habits",
+    "List all habits for the authenticated user",
+    {
+      include_archived: z.boolean().optional().describe("Include archived habits (default: false)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "habits:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getHabits(auth.userId, args.include_archived ?? false);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- get_habit_stats (READ) ---
+  server.tool(
+    "get_habit_stats",
+    "Get completion statistics for a specific habit",
+    {
+      habit_id: z.string().describe("Habit ID"),
+      days: z.number().optional().describe("Number of days to analyze (default: 30)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "habits:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getHabitStats(auth.userId, args.habit_id, args.days ?? 30);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- create_habit (WRITE) ---
+  server.tool(
+    "create_habit",
+    "Create a new habit to track",
+    {
+      name: z.string().describe("Habit name"),
+      description: z.string().optional().describe("Habit description"),
+      frequency: z.string().optional().describe("Frequency: daily, weekly, or custom"),
+      target_days: z.array(z.number()).optional().describe("Days of week to target (0=Sunday, 6=Saturday)"),
+      color: z.string().optional().describe("Color hex code for display"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "habits:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await createHabit(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- toggle_habit (WRITE) ---
+  server.tool(
+    "toggle_habit",
+    "Toggle habit completion for a given date (defaults to today)",
+    {
+      habit_id: z.string().describe("Habit ID"),
+      date: z.string().optional().describe("Date in YYYY-MM-DD format (defaults to today)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "habits:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await toggleHabitLog(auth.userId, args.habit_id, args.date);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/tools/helpers.ts
+++ b/src/lib/mcp/tools/helpers.ts
@@ -1,0 +1,55 @@
+import { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import { ServerRequest, ServerNotification } from "@modelcontextprotocol/sdk/types.js";
+
+export type Extra = RequestHandlerExtra<ServerRequest, ServerNotification>;
+
+interface AuthInfo {
+  extra?: Record<string, unknown>;
+  scopes?: string[];
+}
+
+export interface ExtractedAuth {
+  userId: string;
+  scopes: string[];
+  plan: string;
+}
+
+/** Extract auth info from MCP extra parameter. Returns null if not authenticated. */
+export function getAuth(extra: Extra): ExtractedAuth | null {
+  const authInfo = (extra as unknown as { authInfo?: AuthInfo }).authInfo;
+  const userId = authInfo?.extra?.userId as string | undefined;
+  if (!userId) return null;
+  return {
+    userId,
+    scopes: authInfo?.scopes ?? [],
+    plan: (authInfo?.extra?.plan as string) ?? "free",
+  };
+}
+
+/** Check if the required scope is present. Returns an error message or null. */
+export function checkScope(scopes: string[], required: string): string | null {
+  return scopes.includes(required) ? null : `Insufficient scope: ${required}`;
+}
+
+/** Build a successful text result. */
+export function textResult(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+/** Build an error result. */
+export function errorResult(msg: string) {
+  return {
+    content: [{ type: "text" as const, text: msg }],
+    isError: true as const,
+  };
+}
+
+/** Standard "not authenticated" response. */
+export const NOT_AUTHENTICATED = errorResult("Not authenticated");
+
+/** Standard "paid plan required" response. */
+export const PAID_PLAN_REQUIRED = errorResult(
+  "This action requires a paid plan. Upgrade at https://dailyagent.dev/pricing"
+);

--- a/src/lib/mcp/tools/journal.ts
+++ b/src/lib/mcp/tools/journal.ts
@@ -1,0 +1,163 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, PAID_PLAN_REQUIRED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getJournalEntry(userId: string, date: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("journal_entries")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("entry_date", date)
+    .single();
+
+  return { data, error: error?.code === "PGRST116" ? null : (error?.message ?? null) };
+}
+
+async function getRecentJournalEntries(userId: string, from?: string, to?: string, limit = 10) {
+  const supabase = getServiceClient();
+
+  let query = supabase
+    .from("journal_entries")
+    .select("*")
+    .eq("user_id", userId)
+    .order("entry_date", { ascending: false })
+    .limit(limit);
+
+  if (from) query = query.gte("entry_date", from);
+  if (to) query = query.lte("entry_date", to);
+
+  const { data, error } = await query;
+  return { data, error: error?.message ?? null };
+}
+
+async function searchJournal(userId: string, query: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("journal_entries")
+    .select("*")
+    .eq("user_id", userId)
+    .ilike("content", `%${query}%`)
+    .order("entry_date", { ascending: false })
+    .limit(20);
+
+  return { data, error: error?.message ?? null };
+}
+
+async function createOrUpdateJournalEntry(
+  userId: string,
+  args: {
+    content: string;
+    entry_date?: string;
+    mood?: number;
+  }
+) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+  const entryDate = args.entry_date ?? today;
+
+  const { data, error } = await supabase
+    .from("journal_entries")
+    .upsert(
+      {
+        user_id: userId,
+        entry_date: entryDate,
+        content: args.content,
+        mood: args.mood ?? null,
+      },
+      { onConflict: "user_id,entry_date" }
+    )
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerJournalTools(server: McpServer) {
+  // --- get_journal_entries (READ) ---
+  server.tool(
+    "get_journal_entries",
+    "Get journal entries. Fetches a specific date or a range of entries.",
+    {
+      date: z.string().optional().describe("Specific date in YYYY-MM-DD format"),
+      from: z.string().optional().describe("Start date in YYYY-MM-DD format for a range"),
+      to: z.string().optional().describe("End date in YYYY-MM-DD format for a range"),
+      limit: z.number().optional().describe("Maximum number of entries to return (default: 10)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "journal:read");
+      if (scopeError) return errorResult(scopeError);
+
+      if (args.date) {
+        const result = await getJournalEntry(auth.userId, args.date);
+        if (result.error) return errorResult(`Error: ${result.error}`);
+        return textResult(result.data);
+      }
+
+      const result = await getRecentJournalEntries(auth.userId, args.from, args.to, args.limit ?? 10);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- search_journal (READ) ---
+  server.tool(
+    "search_journal",
+    "Search journal entries by content",
+    {
+      query: z.string().describe("Search query text"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "journal:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await searchJournal(auth.userId, args.query);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- create_journal_entry (WRITE) ---
+  server.tool(
+    "create_journal_entry",
+    "Create or update a journal entry for a given date (defaults to today)",
+    {
+      content: z.string().describe("Journal entry content"),
+      entry_date: z.string().optional().describe("Date in YYYY-MM-DD format (defaults to today)"),
+      mood: z.number().min(1).max(5).optional().describe("Mood rating from 1 (low) to 5 (great)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "journal:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await createOrUpdateJournalEntry(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/tools/reviews.ts
+++ b/src/lib/mcp/tools/reviews.ts
@@ -1,0 +1,113 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, PAID_PLAN_REQUIRED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getReviewForWeek(userId: string, weekStart: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("weekly_reviews")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("week_start", weekStart)
+    .single();
+
+  return { data, error: error?.code === "PGRST116" ? null : (error?.message ?? null) };
+}
+
+async function getLatestReview(userId: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("weekly_reviews")
+    .select("*")
+    .eq("user_id", userId)
+    .order("week_start", { ascending: false })
+    .limit(1)
+    .single();
+
+  return { data, error: error?.code === "PGRST116" ? null : (error?.message ?? null) };
+}
+
+async function saveReview(userId: string, weekStart: string, content: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("weekly_reviews")
+    .upsert(
+      {
+        user_id: userId,
+        week_start: weekStart,
+        content,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "user_id,week_start" }
+    )
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerReviewTools(server: McpServer) {
+  // --- get_weekly_review (READ) ---
+  server.tool(
+    "get_weekly_review",
+    "Get a weekly review. If week_start is provided, fetches that specific week; otherwise returns the latest review.",
+    {
+      week_start: z.string().optional().describe("Week start date in YYYY-MM-DD format"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "review:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = args.week_start
+        ? await getReviewForWeek(auth.userId, args.week_start)
+        : await getLatestReview(auth.userId);
+
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      if (!result.data) {
+        return textResult({ message: "No weekly review found." });
+      }
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- save_weekly_review (WRITE) ---
+  server.tool(
+    "save_weekly_review",
+    "Save or overwrite a weekly review for a given week",
+    {
+      week_start: z.string().describe("Week start date in YYYY-MM-DD format"),
+      content: z.string().describe("Review content (markdown supported)"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "review:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await saveReview(auth.userId, args.week_start, args.content);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/tools/spaces.ts
+++ b/src/lib/mcp/tools/spaces.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, PAID_PLAN_REQUIRED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getSpaces(userId: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("spaces")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  return { data, error: error?.message ?? null };
+}
+
+async function createSpace(
+  userId: string,
+  args: {
+    name: string;
+    description?: string;
+  }
+) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("spaces")
+    .insert({
+      user_id: userId,
+      name: args.name,
+      description: args.description ?? null,
+      status: "active",
+    })
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+async function updateSpace(
+  userId: string,
+  args: {
+    space_id: string;
+    name?: string;
+    description?: string;
+    status?: string;
+  }
+) {
+  const supabase = getServiceClient();
+
+  const updates: Record<string, unknown> = {};
+  if (args.name !== undefined) updates.name = args.name;
+  if (args.description !== undefined) updates.description = args.description;
+  if (args.status !== undefined) updates.status = args.status;
+
+  const { data, error } = await supabase
+    .from("spaces")
+    .update(updates)
+    .eq("id", args.space_id)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerSpaceTools(server: McpServer) {
+  // --- list_spaces (READ) ---
+  server.tool(
+    "list_spaces",
+    "List all spaces (projects) for the authenticated user",
+    {},
+    async (_args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "spaces:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getSpaces(auth.userId);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- create_space (WRITE) ---
+  server.tool(
+    "create_space",
+    "Create a new space (project) to organize tasks",
+    {
+      name: z.string().describe("Space name"),
+      description: z.string().optional().describe("Space description"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "spaces:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await createSpace(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- update_space (WRITE) ---
+  server.tool(
+    "update_space",
+    "Update a space's name, description, or status",
+    {
+      space_id: z.string().describe("Space ID"),
+      name: z.string().optional().describe("New name"),
+      description: z.string().optional().describe("New description"),
+      status: z.string().optional().describe("New status: active or archived"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "spaces:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await updateSpace(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/tools/tasks.ts
+++ b/src/lib/mcp/tools/tasks.ts
@@ -1,0 +1,261 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, PAID_PLAN_REQUIRED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getTasksForDate(userId: string, date?: string, spaceId?: string) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+  const taskDate = date ?? today;
+
+  if (taskDate === today) {
+    let query = supabase
+      .from("tasks")
+      .select("*")
+      .eq("user_id", userId)
+      .or(`task_date.eq.${taskDate},and(task_date.lt.${taskDate},done.eq.false)`)
+      .order("priority", { ascending: true })
+      .order("sort_order", { ascending: true });
+
+    if (spaceId) query = query.eq("space_id", spaceId);
+
+    const { data, error } = await query;
+    return { data, error: error?.message ?? null };
+  }
+
+  let query = supabase
+    .from("tasks")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("task_date", taskDate)
+    .order("priority", { ascending: true })
+    .order("sort_order", { ascending: true });
+
+  if (spaceId) query = query.eq("space_id", spaceId);
+
+  const { data, error } = await query;
+  return { data, error: error?.message ?? null };
+}
+
+async function createTask(
+  userId: string,
+  args: {
+    title: string;
+    notes?: string;
+    priority?: string;
+    task_date?: string;
+    space_id?: string;
+    goal_id?: string;
+  }
+) {
+  const supabase = getServiceClient();
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .insert({
+      user_id: userId,
+      title: args.title,
+      notes: args.notes ?? null,
+      priority: args.priority ?? "B",
+      task_date: args.task_date ?? today,
+      space_id: args.space_id ?? null,
+      goal_id: args.goal_id ?? null,
+      done: false,
+    })
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+async function updateTask(
+  userId: string,
+  args: {
+    task_id: string;
+    title?: string;
+    notes?: string;
+    priority?: string;
+    task_date?: string;
+    done?: boolean;
+  }
+) {
+  const supabase = getServiceClient();
+
+  const updates: Record<string, unknown> = {};
+  if (args.title !== undefined) updates.title = args.title;
+  if (args.notes !== undefined) updates.notes = args.notes;
+  if (args.priority !== undefined) updates.priority = args.priority;
+  if (args.task_date !== undefined) updates.task_date = args.task_date;
+  if (args.done !== undefined) updates.done = args.done;
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .update(updates)
+    .eq("id", args.task_id)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+async function completeTask(userId: string, taskId: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("tasks")
+    .update({ done: true, completed_at: new Date().toISOString() })
+    .eq("id", taskId)
+    .eq("user_id", userId)
+    .select()
+    .single();
+
+  return { data, error: error?.message ?? null };
+}
+
+async function deleteTask(userId: string, taskId: string) {
+  const supabase = getServiceClient();
+
+  const { error } = await supabase
+    .from("tasks")
+    .delete()
+    .eq("id", taskId)
+    .eq("user_id", userId);
+
+  return { error: error?.message ?? null };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerTaskTools(server: McpServer) {
+  // --- list_tasks (READ) ---
+  server.tool(
+    "list_tasks",
+    "List tasks for a given date (defaults to today). Incomplete tasks from previous days are included when viewing today.",
+    {
+      date: z.string().optional().describe("Date in YYYY-MM-DD format (defaults to today)"),
+      space_id: z.string().optional().describe("Filter by space/project ID"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "tasks:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getTasksForDate(auth.userId, args.date, args.space_id);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- create_task (WRITE) ---
+  server.tool(
+    "create_task",
+    "Create a new task",
+    {
+      title: z.string().describe("Task title"),
+      notes: z.string().optional().describe("Additional notes"),
+      priority: z.enum(["A", "B", "C"]).optional().describe("Franklin Covey priority: A (critical), B (important), C (nice to have)"),
+      task_date: z.string().optional().describe("Date in YYYY-MM-DD format (defaults to today)"),
+      space_id: z.string().optional().describe("Space/project ID to assign to"),
+      goal_id: z.string().optional().describe("Goal ID to link to"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "tasks:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await createTask(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- update_task (WRITE) ---
+  server.tool(
+    "update_task",
+    "Update an existing task",
+    {
+      task_id: z.string().describe("Task ID"),
+      title: z.string().optional().describe("New title"),
+      notes: z.string().optional().describe("New notes"),
+      priority: z.enum(["A", "B", "C"]).optional().describe("New priority"),
+      task_date: z.string().optional().describe("New date in YYYY-MM-DD format"),
+      done: z.boolean().optional().describe("Mark as done or not done"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "tasks:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await updateTask(auth.userId, args);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- complete_task (WRITE) ---
+  server.tool(
+    "complete_task",
+    "Mark a task as complete",
+    {
+      task_id: z.string().describe("Task ID to complete"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "tasks:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await completeTask(auth.userId, args.task_id);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- delete_task (WRITE) ---
+  server.tool(
+    "delete_task",
+    "Delete a task permanently",
+    {
+      task_id: z.string().describe("Task ID to delete"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "tasks:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await deleteTask(auth.userId, args.task_id);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult({ success: true });
+    }
+  );
+}

--- a/src/lib/mcp/tools/workouts.ts
+++ b/src/lib/mcp/tools/workouts.ts
@@ -1,0 +1,189 @@
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getServiceClient } from "@/lib/mcp/supabase";
+import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, PAID_PLAN_REQUIRED, Extra } from "./helpers";
+
+// ---------------------------------------------------------------------------
+// Query helpers
+// ---------------------------------------------------------------------------
+
+async function getWorkoutLogs(userId: string, date?: string, from?: string, to?: string) {
+  const supabase = getServiceClient();
+
+  let query = supabase
+    .from("workout_logs")
+    .select("*, workout_log_exercises(*)")
+    .eq("user_id", userId)
+    .order("log_date", { ascending: false });
+
+  if (date) {
+    query = query.eq("log_date", date);
+  } else {
+    if (from) query = query.gte("log_date", from);
+    if (to) query = query.lte("log_date", to);
+    if (!from && !to) query = query.limit(20);
+  }
+
+  const { data, error } = await query;
+  return { data, error: error?.message ?? null };
+}
+
+async function getWorkoutTemplates(userId: string) {
+  const supabase = getServiceClient();
+
+  const { data, error } = await supabase
+    .from("workout_templates")
+    .select("*, workout_exercises(*)")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false });
+
+  return { data, error: error?.message ?? null };
+}
+
+interface ExerciseEntry {
+  name: string;
+  sets?: number;
+  reps?: number;
+  weight?: number;
+  duration_seconds?: number;
+  notes?: string;
+}
+
+async function logWorkout(
+  userId: string,
+  args: {
+    name: string;
+    log_date: string;
+    duration_minutes?: number;
+    notes?: string;
+    exercises?: string;
+  }
+) {
+  const supabase = getServiceClient();
+
+  // Parse exercises JSON if provided
+  let exercises: ExerciseEntry[] = [];
+  if (args.exercises) {
+    try {
+      exercises = JSON.parse(args.exercises) as ExerciseEntry[];
+    } catch {
+      return { data: null, error: "Invalid exercises JSON format" };
+    }
+  }
+
+  const { data: log, error: logError } = await supabase
+    .from("workout_logs")
+    .insert({
+      user_id: userId,
+      name: args.name,
+      log_date: args.log_date,
+      duration_minutes: args.duration_minutes ?? null,
+      notes: args.notes ?? null,
+    })
+    .select()
+    .single();
+
+  if (logError || !log) {
+    return { data: null, error: logError?.message ?? "Failed to create workout log" };
+  }
+
+  // Insert exercises if provided
+  if (exercises.length > 0) {
+    // Pack individual set fields into the sets JSONB array format the DB uses
+    const exerciseRows = exercises.map((ex) => ({
+      log_id: log.id,
+      exercise_name: ex.name,
+      sets: ex.sets != null
+        ? Array.from({ length: ex.sets }, () => ({
+            reps: ex.reps,
+            weight: ex.weight,
+            duration: ex.duration_seconds,
+          }))
+        : [],
+    }));
+
+    const { error: exError } = await supabase.from("workout_log_exercises").insert(exerciseRows);
+    if (exError) {
+      return { data: log, error: `Workout created but exercises failed: ${exError.message}` };
+    }
+  }
+
+  return { data: { ...log, exercises }, error: null };
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerWorkoutTools(server: McpServer) {
+  // --- list_workout_logs (READ) ---
+  server.tool(
+    "list_workout_logs",
+    "List workout logs, optionally filtered by date or date range",
+    {
+      date: z.string().optional().describe("Specific date in YYYY-MM-DD format"),
+      from: z.string().optional().describe("Start date in YYYY-MM-DD format"),
+      to: z.string().optional().describe("End date in YYYY-MM-DD format"),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "workouts:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getWorkoutLogs(auth.userId, args.date, args.from, args.to);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- list_workout_templates (READ) ---
+  server.tool(
+    "list_workout_templates",
+    "List all saved workout templates",
+    {},
+    async (_args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "workouts:read");
+      if (scopeError) return errorResult(scopeError);
+
+      const result = await getWorkoutTemplates(auth.userId);
+      if (result.error) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+
+  // --- log_workout (WRITE) ---
+  server.tool(
+    "log_workout",
+    "Log a completed workout",
+    {
+      name: z.string().describe("Workout name"),
+      log_date: z.string().describe("Date of the workout in YYYY-MM-DD format"),
+      duration_minutes: z.number().optional().describe("Duration in minutes"),
+      notes: z.string().optional().describe("Workout notes"),
+      exercises: z.string().optional().describe(
+        "JSON string array of exercises, e.g. [{\"name\":\"Squat\",\"sets\":3,\"reps\":10,\"weight\":100}]"
+      ),
+    },
+    async (args, extra: Extra) => {
+      const auth = getAuth(extra);
+      if (!auth) return NOT_AUTHENTICATED;
+
+      const scopeError = checkScope(auth.scopes, "workouts:write");
+      if (scopeError) return errorResult(scopeError);
+
+      if (auth.plan !== "active") return PAID_PLAN_REQUIRED;
+
+      const result = await logWorkout(auth.userId, args);
+      if (result.error && !result.data) return errorResult(`Error: ${result.error}`);
+
+      return textResult(result.data);
+    }
+  );
+}

--- a/src/lib/mcp/types.ts
+++ b/src/lib/mcp/types.ts
@@ -1,0 +1,18 @@
+import { SupabaseClient } from "@supabase/supabase-js";
+import { AuthResult } from "@/lib/token-validation";
+
+/** Context available to every MCP tool/resource/prompt handler */
+export interface McpContext {
+  userId: string;
+  supabase: SupabaseClient;
+  auth: AuthResult;
+  plan: UserPlan;
+}
+
+export type UserPlan = "free" | "active" | "canceled" | "expired";
+
+/** Standard query result shape */
+export interface QueryResult<T> {
+  data: T | null;
+  error: string | null;
+}


### PR DESCRIPTION
## Summary
- Full MCP server at `/api/mcp` with Streamable HTTP transport
- Dual auth: OAuth (Hydra) + API key (`da_sk_` prefix)
- 15 resources, 31 tools, 13 prompt templates across all productivity domains
- Scope enforcement on every operation
- Plan gating: read tools for all, write tools require paid plan
- Daily rate limits: 500 free / 10,000 paid
- 57 new tests (167 total, all passing)
- Fix 4 pre-existing admin limits test failures

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm test` — 167/167 passing
- [ ] E2E test after Vercel deploy: connect Claude Desktop/Code, read resources, call tools
- [ ] Test OAuth flow: Hydra → login → consent → token → MCP request
- [ ] Test API key flow: Bearer da_sk_... → MCP request
- [ ] Test scope enforcement: restricted token can't call unauthorized tools
- [ ] Test plan gating: free user blocked from write tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)