### PR TITLE
Code review sweep: dedupe serializers, harden schema, fix bugs across 12 domains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,6 @@ Located at `/api/mcp`. Uses the official `@modelcontextprotocol/sdk` with Stream
 - `src/lib/db/client.ts` — Drizzle + postgres.js client (lazy-init so build doesn't need DATABASE_URL)
 - `src/lib/db/schema.ts` — All table defs
 - `src/lib/auth.ts` — `getUserId()` reading `SELF_HOSTED_USER_ID`
-- `src/lib/admin.ts` — Admin access helpers (single-user: always true)
 - `src/lib/dates.ts` — Date utilities
 - `src/lib/theme.tsx` — ThemeProvider (light/dark/system)
 - `src/lib/retry.ts` — Retry utility

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,13 +73,14 @@ Located at `/api/mcp`. Uses the official `@modelcontextprotocol/sdk` with Stream
 
 - `src/lib/db/client.ts` — Drizzle + postgres.js client (lazy-init so build doesn't need DATABASE_URL)
 - `src/lib/db/schema.ts` — All table defs
+- `src/lib/db/optimistic.ts` — Optimistic concurrency helper (version-based update)
 - `src/lib/auth.ts` — `getUserId()` reading `SELF_HOSTED_USER_ID`
 - `src/lib/dates.ts` — Date utilities
 - `src/lib/theme.tsx` — ThemeProvider (light/dark/system)
 - `src/lib/retry.ts` — Retry utility
 - `src/lib/token-validation.ts` — MCP bearer-token validation
 - `src/lib/oauth-scopes.ts` — Scope list + `all` expansion
-- `src/types/database.ts` — Legacy TS types still imported by some UI components (harmless; will be regenerated from Drizzle later)
+- `src/types/database.ts` — Serialized JSON shapes for dashboard API routes (snake_case); keep in sync with `schema.ts`
 
 ### Components
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -42,7 +42,6 @@ services:
       MCP_API_KEY: ${MCP_API_KEY}
       NEXT_PUBLIC_SITE_NAME: ${NEXT_PUBLIC_SITE_NAME:-Daily Agent MCP}
       NEXT_PUBLIC_SITE_DESCRIPTION: ${NEXT_PUBLIC_SITE_DESCRIPTION:-Your productivity dashboard}
-      NODE_ENV: production
     ports:
       # Localhost by default. If you're fronting this with Tailscale or a reverse
       # proxy, replace "127.0.0.1" with your Tailscale IP (e.g. "100.x.y.z:3000:3000").

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,10 +29,10 @@ services:
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-dailyagent}:${POSTGRES_PASSWORD:-dailyagent}@postgres:5432/${POSTGRES_DB:-dailyagent}
       SELF_HOSTED_USER_ID: ${SELF_HOSTED_USER_ID}
+      SELF_HOSTED_USER_EMAIL: ${SELF_HOSTED_USER_EMAIL:-user@localhost}
       MCP_API_KEY: ${MCP_API_KEY}
       NEXT_PUBLIC_SITE_NAME: ${NEXT_PUBLIC_SITE_NAME:-Daily Agent MCP}
       NEXT_PUBLIC_SITE_DESCRIPTION: ${NEXT_PUBLIC_SITE_DESCRIPTION:-Your productivity dashboard}
-      NODE_ENV: production
     ports:
       # Bind to loopback only — Tailscale / reverse proxy handles external access
       - "127.0.0.1:3000:3000"

--- a/drizzle/0004_silent_prima.sql
+++ b/drizzle/0004_silent_prima.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "daily_briefings" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "daily_briefings" ALTER COLUMN "updated_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "insight_cache" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "profiles" ALTER COLUMN "timezone" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "profiles" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "profiles" ALTER COLUMN "updated_at" SET NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX "journal_entries_user_date_unique" ON "journal_entries" USING btree ("user_id","entry_date");--> statement-breakpoint
+CREATE INDEX "idx_workout_logs_template" ON "workout_logs" USING btree ("template_id");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,2109 @@
+{
+  "id": "53224b0b-2e35-4024-9c5c-ae081869b5f4",
+  "prevId": "442c2ad6-5ab8-4f63-b6d4-443b1473f877",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.daily_briefings": {
+      "name": "daily_briefings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "briefing_date": {
+          "name": "briefing_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "daily_briefings_user_date_unique": {
+          "name": "daily_briefings_user_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "briefing_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_briefings_user_id_profiles_id_fk": {
+          "name": "daily_briefings_user_id_profiles_id_fk",
+          "tableFrom": "daily_briefings",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.focus_sessions": {
+      "name": "focus_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 25
+        },
+        "break_minutes": {
+          "name": "break_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_focus_sessions_user": {
+          "name": "idx_focus_sessions_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_focus_sessions_user_date": {
+          "name": "idx_focus_sessions_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_focus_sessions_task": {
+          "name": "idx_focus_sessions_task",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "focus_sessions_user_id_profiles_id_fk": {
+          "name": "focus_sessions_user_id_profiles_id_fk",
+          "tableFrom": "focus_sessions",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "focus_sessions_task_id_tasks_id_fk": {
+          "name": "focus_sessions_task_id_tasks_id_fk",
+          "tableFrom": "focus_sessions",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "focus_sessions_status_check": {
+          "name": "focus_sessions_status_check",
+          "value": "\"focus_sessions\".\"status\" IN ('active', 'completed', 'cancelled')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.goal_progress_logs": {
+      "name": "goal_progress_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_date": {
+          "name": "log_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_goal_progress_logs_user_date": {
+          "name": "idx_goal_progress_logs_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "log_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "goal_progress_logs_goal_date_unique": {
+          "name": "goal_progress_logs_goal_date_unique",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "log_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goal_progress_logs_goal_id_goals_id_fk": {
+          "name": "goal_progress_logs_goal_id_goals_id_fk",
+          "tableFrom": "goal_progress_logs",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "goal_progress_logs_user_id_profiles_id_fk": {
+          "name": "goal_progress_logs_user_id_profiles_id_fk",
+          "tableFrom": "goal_progress_logs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "goal_progress_logs_progress_check": {
+          "name": "goal_progress_logs_progress_check",
+          "value": "\"goal_progress_logs\".\"progress\" >= 0 AND \"goal_progress_logs\".\"progress\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'personal'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "progress_mode": {
+          "name": "progress_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_goals_user_status": {
+          "name": "idx_goals_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "goals_user_id_profiles_id_fk": {
+          "name": "goals_user_id_profiles_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "goals_category_check": {
+          "name": "goals_category_check",
+          "value": "\"goals\".\"category\" IN ('health', 'career', 'personal', 'financial', 'learning', 'relationships', 'other')"
+        },
+        "goals_status_check": {
+          "name": "goals_status_check",
+          "value": "\"goals\".\"status\" IN ('active', 'completed', 'abandoned')"
+        },
+        "goals_progress_check": {
+          "name": "goals_progress_check",
+          "value": "\"goals\".\"progress\" >= 0 AND \"goals\".\"progress\" <= 100"
+        },
+        "goals_progress_mode_check": {
+          "name": "goals_progress_mode_check",
+          "value": "\"goals\".\"progress_mode\" IN ('auto', 'manual')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.habit_logs": {
+      "name": "habit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "habit_id": {
+          "name": "habit_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_date": {
+          "name": "log_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_habit_logs_habit_date": {
+          "name": "idx_habit_logs_habit_date",
+          "columns": [
+            {
+              "expression": "habit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "log_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_habit_logs_user_date": {
+          "name": "idx_habit_logs_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "log_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "habit_logs_habit_date_unique": {
+          "name": "habit_logs_habit_date_unique",
+          "columns": [
+            {
+              "expression": "habit_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "log_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "habit_logs_habit_id_habits_id_fk": {
+          "name": "habit_logs_habit_id_habits_id_fk",
+          "tableFrom": "habit_logs",
+          "tableTo": "habits",
+          "columnsFrom": [
+            "habit_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "habit_logs_user_id_profiles_id_fk": {
+          "name": "habit_logs_user_id_profiles_id_fk",
+          "tableFrom": "habit_logs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.habits": {
+      "name": "habits",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "target_days": {
+          "name": "target_days",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{1,2,3,4,5,6,7}'"
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#d4a574'"
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_habits_user": {
+          "name": "idx_habits_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_habits_goal": {
+          "name": "idx_habits_goal",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "habits_user_id_profiles_id_fk": {
+          "name": "habits_user_id_profiles_id_fk",
+          "tableFrom": "habits",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "habits_goal_id_goals_id_fk": {
+          "name": "habits_goal_id_goals_id_fk",
+          "tableFrom": "habits",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "habits_frequency_check": {
+          "name": "habits_frequency_check",
+          "value": "\"habits\".\"frequency\" IN ('daily', 'weekly')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.insight_cache": {
+      "name": "insight_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_date": {
+          "name": "cache_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "insights": {
+          "name": "insights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "insight_cache_user_date_unique": {
+          "name": "insight_cache_user_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cache_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "insight_cache_user_id_profiles_id_fk": {
+          "name": "insight_cache_user_id_profiles_id_fk",
+          "tableFrom": "insight_cache",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entry_date": {
+          "name": "entry_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_journal_user_date": {
+          "name": "idx_journal_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "journal_entries_user_date_unique": {
+          "name": "journal_entries_user_date_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entry_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_journal_search": {
+          "name": "idx_journal_search",
+          "columns": [
+            {
+              "expression": "to_tsvector('english', \"content\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_user_id_profiles_id_fk": {
+          "name": "journal_entries_user_id_profiles_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "journal_mood_check": {
+          "name": "journal_mood_check",
+          "value": "\"journal_entries\".\"mood\" >= 1 AND \"journal_entries\".\"mood\" <= 5"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UTC'"
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ai_model_config": {
+          "name": "ai_model_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_calling_enabled": {
+          "name": "tool_calling_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "briefing_enabled": {
+          "name": "briefing_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "onboarded_at": {
+          "name": "onboarded_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.spaces": {
+      "name": "spaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "deadline": {
+          "name": "deadline",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_spaces_user": {
+          "name": "idx_spaces_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_spaces_user_status": {
+          "name": "idx_spaces_user_status",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "spaces_user_id_profiles_id_fk": {
+          "name": "spaces_user_id_profiles_id_fk",
+          "tableFrom": "spaces",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "spaces_status_check": {
+          "name": "spaces_status_check",
+          "value": "\"spaces\".\"status\" IN ('active', 'paused', 'completed')"
+        },
+        "spaces_progress_check": {
+          "name": "spaces_progress_check",
+          "value": "\"spaces\".\"progress\" >= 0 AND \"spaces\".\"progress\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'#94a3b8'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tags_user_name_unique": {
+          "name": "tags_user_name_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tags_user_id_profiles_id_fk": {
+          "name": "tags_user_id_profiles_id_fk",
+          "tableFrom": "tags",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasks": {
+      "name": "tasks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'B1'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "done": {
+          "name": "done",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "done_at": {
+          "name": "done_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_date": {
+          "name": "task_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "rolled_from": {
+          "name": "rolled_from",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goal_id": {
+          "name": "goal_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_tasks_user_date": {
+          "name": "idx_tasks_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "task_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_user_done": {
+          "name": "idx_tasks_user_done",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "done",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_space": {
+          "name": "idx_tasks_space",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_tasks_goal": {
+          "name": "idx_tasks_goal",
+          "columns": [
+            {
+              "expression": "goal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasks_user_id_profiles_id_fk": {
+          "name": "tasks_user_id_profiles_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasks_rolled_from_tasks_id_fk": {
+          "name": "tasks_rolled_from_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "rolled_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_space_id_spaces_id_fk": {
+          "name": "tasks_space_id_spaces_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "spaces",
+          "columnsFrom": [
+            "space_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "tasks_goal_id_goals_id_fk": {
+          "name": "tasks_goal_id_goals_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "goals",
+          "columnsFrom": [
+            "goal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "tasks_priority_check": {
+          "name": "tasks_priority_check",
+          "value": "\"tasks\".\"priority\" ~ '^[A-C][1-9]$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.weekly_reviews": {
+      "name": "weekly_reviews",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_weekly_reviews_user": {
+          "name": "idx_weekly_reviews_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "weekly_reviews_user_week_unique": {
+          "name": "weekly_reviews_user_week_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "weekly_reviews_user_id_profiles_id_fk": {
+          "name": "weekly_reviews_user_id_profiles_id_fk",
+          "tableFrom": "weekly_reviews",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_exercises": {
+      "name": "workout_exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_type": {
+          "name": "exercise_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'strength'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "default_sets": {
+          "name": "default_sets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "default_reps": {
+          "name": "default_reps",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "default_weight": {
+          "name": "default_weight",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration": {
+          "name": "default_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_workout_exercises_template": {
+          "name": "idx_workout_exercises_template",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_exercises_template_id_workout_templates_id_fk": {
+          "name": "workout_exercises_template_id_workout_templates_id_fk",
+          "tableFrom": "workout_exercises",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "workout_exercises_type_check": {
+          "name": "workout_exercises_type_check",
+          "value": "\"workout_exercises\".\"exercise_type\" IN ('strength', 'timed', 'cardio')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.workout_log_exercises": {
+      "name": "workout_log_exercises",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "log_id": {
+          "name": "log_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_name": {
+          "name": "exercise_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "exercise_type": {
+          "name": "exercise_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'strength'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sets": {
+          "name": "sets",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "idx_workout_log_exercises_log": {
+          "name": "idx_workout_log_exercises_log",
+          "columns": [
+            {
+              "expression": "log_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_log_exercises_log_id_workout_logs_id_fk": {
+          "name": "workout_log_exercises_log_id_workout_logs_id_fk",
+          "tableFrom": "workout_log_exercises",
+          "tableTo": "workout_logs",
+          "columnsFrom": [
+            "log_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_logs": {
+      "name": "workout_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_date": {
+          "name": "log_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workout_logs_user_date": {
+          "name": "idx_workout_logs_user_date",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "log_date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_workout_logs_template": {
+          "name": "idx_workout_logs_template",
+          "columns": [
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_logs_user_id_profiles_id_fk": {
+          "name": "workout_logs_user_id_profiles_id_fk",
+          "tableFrom": "workout_logs",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "workout_logs_template_id_workout_templates_id_fk": {
+          "name": "workout_logs_template_id_workout_templates_id_fk",
+          "tableFrom": "workout_logs",
+          "tableTo": "workout_templates",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workout_templates": {
+      "name": "workout_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_workout_templates_user": {
+          "name": "idx_workout_templates_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "workout_templates_user_id_profiles_id_fk": {
+          "name": "workout_templates_user_id_profiles_id_fk",
+          "tableFrom": "workout_templates",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776781739296,
       "tag": "0003_tough_callisto",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1776867784952,
+      "tag": "0004_silent_prima",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/focus/[id]/route.ts
+++ b/src/app/api/focus/[id]/route.ts
@@ -5,21 +5,7 @@ import { eq, and } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
 import { updateWithVersion } from "@/lib/db/optimistic";
 import { conflictResponse } from "@/lib/api-conflict";
-
-function serializeSession(s: typeof focusSessions.$inferSelect) {
-  return {
-    id: s.id,
-    user_id: s.userId,
-    task_id: s.taskId,
-    duration_minutes: s.durationMinutes,
-    break_minutes: s.breakMinutes,
-    started_at: s.startedAt,
-    completed_at: s.completedAt,
-    status: s.status,
-    notes: s.notes,
-    updated_at: s.updatedAt,
-  };
-}
+import { serializeSession } from "@/lib/mcp/queries/focus";
 
 export async function PATCH(
   request: NextRequest,

--- a/src/app/api/focus/route.ts
+++ b/src/app/api/focus/route.ts
@@ -3,21 +3,7 @@ import { db } from "@/lib/db/client";
 import { focusSessions } from "@/lib/db/schema";
 import { eq, and, gte, lte, desc } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeSession(s: typeof focusSessions.$inferSelect) {
-  return {
-    id: s.id,
-    user_id: s.userId,
-    task_id: s.taskId,
-    duration_minutes: s.durationMinutes,
-    break_minutes: s.breakMinutes,
-    started_at: s.startedAt,
-    completed_at: s.completedAt,
-    status: s.status,
-    notes: s.notes,
-    updated_at: s.updatedAt,
-  };
-}
+import { serializeSession } from "@/lib/mcp/queries/focus";
 
 export async function GET(request: NextRequest) {
   const userId = getUserId();

--- a/src/app/api/goals/[id]/route.ts
+++ b/src/app/api/goals/[id]/route.ts
@@ -5,61 +5,9 @@ import { eq, and, asc } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
 import { updateWithVersion } from "@/lib/db/optimistic";
 import { conflictResponse } from "@/lib/api-conflict";
-
-function serializeGoal(g: typeof goals.$inferSelect) {
-  return {
-    id: g.id,
-    user_id: g.userId,
-    title: g.title,
-    description: g.description,
-    category: g.category,
-    status: g.status,
-    progress: g.progress,
-    progress_mode: g.progressMode,
-    target_date: g.targetDate,
-    completed_at: g.completedAt,
-    sort_order: g.sortOrder,
-    created_at: g.createdAt,
-    updated_at: g.updatedAt,
-  };
-}
-
-function serializeTask(t: typeof tasks.$inferSelect) {
-  return {
-    id: t.id,
-    user_id: t.userId,
-    title: t.title,
-    notes: t.notes,
-    priority: t.priority,
-    sort_order: t.sortOrder,
-    done: t.done,
-    done_at: t.doneAt,
-    task_date: t.taskDate,
-    rolled_from: t.rolledFrom,
-    space_id: t.spaceId,
-    goal_id: t.goalId,
-    recurrence: t.recurrence,
-    created_at: t.createdAt,
-    updated_at: t.updatedAt,
-  };
-}
-
-function serializeHabit(h: typeof habits.$inferSelect) {
-  return {
-    id: h.id,
-    user_id: h.userId,
-    name: h.name,
-    description: h.description,
-    frequency: h.frequency,
-    target_days: h.targetDays,
-    color: h.color,
-    archived: h.archived,
-    sort_order: h.sortOrder,
-    goal_id: h.goalId,
-    created_at: h.createdAt,
-    updated_at: h.updatedAt,
-  };
-}
+import { serializeGoal } from "@/lib/mcp/queries/goals";
+import { serializeTask } from "@/lib/mcp/queries/tasks";
+import { serializeHabit } from "@/lib/mcp/queries/habits";
 
 export async function GET(
   _request: NextRequest,

--- a/src/app/api/goals/route.ts
+++ b/src/app/api/goals/route.ts
@@ -3,24 +3,7 @@ import { db } from "@/lib/db/client";
 import { goals, tasks, habits, habitLogs, goalProgressLogs } from "@/lib/db/schema";
 import { eq, and, asc, desc, inArray } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeGoal(g: typeof goals.$inferSelect) {
-  return {
-    id: g.id,
-    user_id: g.userId,
-    title: g.title,
-    description: g.description,
-    category: g.category,
-    status: g.status,
-    progress: g.progress,
-    progress_mode: g.progressMode,
-    target_date: g.targetDate,
-    completed_at: g.completedAt,
-    sort_order: g.sortOrder,
-    created_at: g.createdAt,
-    updated_at: g.updatedAt,
-  };
-}
+import { serializeGoal } from "@/lib/mcp/queries/goals";
 
 export async function GET(request: NextRequest) {
   const userId = getUserId();

--- a/src/app/api/habits/[id]/route.ts
+++ b/src/app/api/habits/[id]/route.ts
@@ -5,23 +5,7 @@ import { eq, and } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
 import { updateWithVersion } from "@/lib/db/optimistic";
 import { conflictResponse } from "@/lib/api-conflict";
-
-function serializeHabit(h: typeof habits.$inferSelect) {
-  return {
-    id: h.id,
-    user_id: h.userId,
-    name: h.name,
-    description: h.description,
-    frequency: h.frequency,
-    target_days: h.targetDays,
-    color: h.color,
-    archived: h.archived,
-    sort_order: h.sortOrder,
-    goal_id: h.goalId,
-    created_at: h.createdAt,
-    updated_at: h.updatedAt,
-  };
-}
+import { serializeHabit } from "@/lib/mcp/queries/habits";
 
 export async function GET(
   _request: NextRequest,

--- a/src/app/api/habits/route.ts
+++ b/src/app/api/habits/route.ts
@@ -3,23 +3,7 @@ import { db } from "@/lib/db/client";
 import { habits } from "@/lib/db/schema";
 import { eq, and, asc } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeHabit(h: typeof habits.$inferSelect) {
-  return {
-    id: h.id,
-    user_id: h.userId,
-    name: h.name,
-    description: h.description,
-    frequency: h.frequency,
-    target_days: h.targetDays,
-    color: h.color,
-    archived: h.archived,
-    sort_order: h.sortOrder,
-    goal_id: h.goalId,
-    created_at: h.createdAt,
-    updated_at: h.updatedAt,
-  };
-}
+import { serializeHabit } from "@/lib/mcp/queries/habits";
 
 export async function GET(request: NextRequest) {
   const userId = getUserId();

--- a/src/app/api/journal/[id]/route.ts
+++ b/src/app/api/journal/[id]/route.ts
@@ -5,18 +5,7 @@ import { eq, and } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
 import { updateWithVersion } from "@/lib/db/optimistic";
 import { conflictResponse } from "@/lib/api-conflict";
-
-function serializeEntry(e: typeof journalEntries.$inferSelect) {
-  return {
-    id: e.id,
-    user_id: e.userId,
-    entry_date: e.entryDate,
-    content: e.content,
-    mood: e.mood,
-    created_at: e.createdAt,
-    updated_at: e.updatedAt,
-  };
-}
+import { serializeEntry } from "@/lib/mcp/queries/journal";
 
 export async function GET(
   _request: NextRequest,

--- a/src/app/api/journal/route.ts
+++ b/src/app/api/journal/route.ts
@@ -3,18 +3,7 @@ import { db } from "@/lib/db/client";
 import { journalEntries } from "@/lib/db/schema";
 import { eq, and, gte, lte, desc, sql } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeEntry(e: typeof journalEntries.$inferSelect) {
-  return {
-    id: e.id,
-    user_id: e.userId,
-    entry_date: e.entryDate,
-    content: e.content,
-    mood: e.mood,
-    created_at: e.createdAt,
-    updated_at: e.updatedAt,
-  };
-}
+import { serializeEntry } from "@/lib/mcp/queries/journal";
 
 export async function GET(request: NextRequest) {
   const userId = getUserId();

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -5,7 +5,7 @@ import { authenticateMcpRequest } from "@/lib/mcp/auth";
 
 /**
  * MCP Server endpoint — handles all MCP communication via Streamable HTTP.
- * Auth: Bearer token (API key with da_sk_ prefix).
+ * Auth: Bearer token must match MCP_API_KEY env var.
  * Stateless: each request is independently authenticated.
  */
 

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -39,7 +39,7 @@ async function handleMcpRequest(request: NextRequest): Promise<Response> {
   // Pass auth info so tool/resource handlers can access userId and scopes
   const response = await transport.handleRequest(request, {
     authInfo: {
-      token: authHeader?.replace(/^Bearer\s+/i, "") ?? "",
+      token: "",
       clientId: auth.clientId ?? "",
       scopes: auth.scopes,
       extra: {

--- a/src/app/api/spaces/[id]/route.ts
+++ b/src/app/api/spaces/[id]/route.ts
@@ -40,9 +40,16 @@ export async function PATCH(
   const body = await request.json();
 
   const allowedFields: Partial<typeof spaces.$inferInsert> = {};
-  if (typeof body.name === "string") allowedFields.name = body.name;
-  if (typeof body.description === "string" || body.description === null)
-    allowedFields.description = body.description;
+  if (typeof body.name === "string") {
+    const trimmed = body.name.trim();
+    if (trimmed.length === 0) {
+      return NextResponse.json({ error: "Name cannot be empty" }, { status: 400 });
+    }
+    allowedFields.name = trimmed;
+  }
+  if (typeof body.description === "string")
+    allowedFields.description = body.description.trim();
+  else if (body.description === null) allowedFields.description = null;
   if (typeof body.status === "string" && ["active", "paused", "completed"].includes(body.status))
     allowedFields.status = body.status as "active" | "paused" | "completed";
   if (typeof body.progress === "number" && body.progress >= 0 && body.progress <= 100)

--- a/src/app/api/spaces/[id]/route.ts
+++ b/src/app/api/spaces/[id]/route.ts
@@ -5,20 +5,7 @@ import { eq, and } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
 import { updateWithVersion } from "@/lib/db/optimistic";
 import { conflictResponse } from "@/lib/api-conflict";
-
-function serializeSpace(s: typeof spaces.$inferSelect) {
-  return {
-    id: s.id,
-    user_id: s.userId,
-    name: s.name,
-    description: s.description,
-    status: s.status,
-    progress: s.progress,
-    deadline: s.deadline,
-    created_at: s.createdAt,
-    updated_at: s.updatedAt,
-  };
-}
+import { serializeSpace } from "@/lib/mcp/queries/spaces";
 
 export async function GET(
   _request: NextRequest,

--- a/src/app/api/spaces/route.ts
+++ b/src/app/api/spaces/route.ts
@@ -3,20 +3,7 @@ import { db } from "@/lib/db/client";
 import { spaces } from "@/lib/db/schema";
 import { eq, and, desc } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeSpace(s: typeof spaces.$inferSelect) {
-  return {
-    id: s.id,
-    user_id: s.userId,
-    name: s.name,
-    description: s.description,
-    status: s.status,
-    progress: s.progress,
-    deadline: s.deadline,
-    created_at: s.createdAt,
-    updated_at: s.updatedAt,
-  };
-}
+import { serializeSpace } from "@/lib/mcp/queries/spaces";
 
 export async function GET(request: NextRequest) {
   const userId = getUserId();
@@ -48,7 +35,7 @@ export async function POST(request: NextRequest) {
   const body = await request.json();
   const { name, description, status, deadline } = body;
 
-  if (!name || typeof name !== "string") {
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
     return NextResponse.json({ error: "Name is required" }, { status: 400 });
   }
 
@@ -57,8 +44,8 @@ export async function POST(request: NextRequest) {
       .insert(spaces)
       .values({
         userId,
-        name,
-        description: description || null,
+        name: name.trim(),
+        description: description?.trim() || null,
         status: status || "active",
         deadline: deadline || null,
       })

--- a/src/app/api/tags/[id]/route.ts
+++ b/src/app/api/tags/[id]/route.ts
@@ -3,16 +3,7 @@ import { db } from "@/lib/db/client";
 import { tags } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeTag(t: typeof tags.$inferSelect) {
-  return {
-    id: t.id,
-    user_id: t.userId,
-    name: t.name,
-    color: t.color,
-    created_at: t.createdAt,
-  };
-}
+import { serializeTag } from "@/lib/mcp/queries/tags";
 
 export async function PATCH(
   request: NextRequest,
@@ -23,7 +14,13 @@ export async function PATCH(
 
   const body = await request.json();
   const allowedFields: Partial<typeof tags.$inferInsert> = {};
-  if (typeof body.name === "string") allowedFields.name = body.name.trim();
+  if (typeof body.name === "string") {
+    const trimmed = body.name.trim();
+    if (trimmed.length === 0) {
+      return NextResponse.json({ error: "Name cannot be empty" }, { status: 400 });
+    }
+    allowedFields.name = trimmed;
+  }
   if (typeof body.color === "string") allowedFields.color = body.color;
 
   if (Object.keys(allowedFields).length === 0) {

--- a/src/app/api/tags/route.ts
+++ b/src/app/api/tags/route.ts
@@ -3,16 +3,7 @@ import { db } from "@/lib/db/client";
 import { tags } from "@/lib/db/schema";
 import { eq, asc } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeTag(t: typeof tags.$inferSelect) {
-  return {
-    id: t.id,
-    user_id: t.userId,
-    name: t.name,
-    color: t.color,
-    created_at: t.createdAt,
-  };
-}
+import { serializeTag } from "@/lib/mcp/queries/tags";
 
 export async function GET() {
   const userId = getUserId();
@@ -36,7 +27,7 @@ export async function POST(request: NextRequest) {
   const body = await request.json();
   const { name, color } = body;
 
-  if (!name || typeof name !== "string") {
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
     return NextResponse.json({ error: "Name is required" }, { status: 400 });
   }
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -5,47 +5,7 @@ import { eq, and } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
 import { updateWithVersion } from "@/lib/db/optimistic";
 import { conflictResponse } from "@/lib/api-conflict";
-
-function serializeTask(t: typeof tasks.$inferSelect) {
-  return {
-    id: t.id,
-    user_id: t.userId,
-    title: t.title,
-    notes: t.notes,
-    priority: t.priority,
-    sort_order: t.sortOrder,
-    done: t.done,
-    done_at: t.doneAt,
-    task_date: t.taskDate,
-    rolled_from: t.rolledFrom,
-    space_id: t.spaceId,
-    goal_id: t.goalId,
-    recurrence: t.recurrence,
-    created_at: t.createdAt,
-    updated_at: t.updatedAt,
-  };
-}
-
-function getNextOccurrence(taskDate: string, recurrence: { type: string; days?: number[] }): string {
-  const d = new Date(taskDate + "T00:00:00");
-  switch (recurrence.type) {
-    case "daily":
-      d.setDate(d.getDate() + 1);
-      break;
-    case "weekdays": {
-      d.setDate(d.getDate() + 1);
-      while (d.getDay() === 0 || d.getDay() === 6) d.setDate(d.getDate() + 1);
-      break;
-    }
-    case "weekly":
-      d.setDate(d.getDate() + 7);
-      break;
-    case "monthly":
-      d.setMonth(d.getMonth() + 1);
-      break;
-  }
-  return d.toISOString().split("T")[0];
-}
+import { serializeTask, getNextOccurrence } from "@/lib/mcp/queries/tasks";
 
 export async function GET(
   _request: NextRequest,

--- a/src/app/api/tasks/reorder/route.ts
+++ b/src/app/api/tasks/reorder/route.ts
@@ -28,7 +28,7 @@ export async function PATCH(request: NextRequest) {
       for (const item of taskItems as { id: string; sort_order: number }[]) {
         await tx
           .update(tasks)
-          .set({ sortOrder: item.sort_order })
+          .set({ sortOrder: item.sort_order, updatedAt: new Date() })
           .where(and(eq(tasks.id, item.id), eq(tasks.userId, userId)));
       }
     });

--- a/src/app/api/tasks/rollover/route.ts
+++ b/src/app/api/tasks/rollover/route.ts
@@ -3,26 +3,7 @@ import { db } from "@/lib/db/client";
 import { tasks } from "@/lib/db/schema";
 import { eq, and, lt, isNull, inArray } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeTask(t: typeof tasks.$inferSelect) {
-  return {
-    id: t.id,
-    user_id: t.userId,
-    title: t.title,
-    notes: t.notes,
-    priority: t.priority,
-    sort_order: t.sortOrder,
-    done: t.done,
-    done_at: t.doneAt,
-    task_date: t.taskDate,
-    rolled_from: t.rolledFrom,
-    space_id: t.spaceId,
-    goal_id: t.goalId,
-    recurrence: t.recurrence,
-    created_at: t.createdAt,
-    updated_at: t.updatedAt,
-  };
-}
+import { serializeTask } from "@/lib/mcp/queries/tasks";
 
 export async function POST(_request: NextRequest) {
   void _request;
@@ -65,7 +46,7 @@ export async function POST(_request: NextRequest) {
 
       await tx
         .update(tasks)
-        .set({ done: true })
+        .set({ done: true, doneAt: new Date(), updatedAt: new Date() })
         .where(inArray(tasks.id, undoneTasks.map((t) => t.id)));
 
       return inserted;

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -3,26 +3,7 @@ import { db } from "@/lib/db/client";
 import { tasks } from "@/lib/db/schema";
 import { eq, and, or, lt, asc } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeTask(t: typeof tasks.$inferSelect) {
-  return {
-    id: t.id,
-    user_id: t.userId,
-    title: t.title,
-    notes: t.notes,
-    priority: t.priority,
-    sort_order: t.sortOrder,
-    done: t.done,
-    done_at: t.doneAt,
-    task_date: t.taskDate,
-    rolled_from: t.rolledFrom,
-    space_id: t.spaceId,
-    goal_id: t.goalId,
-    recurrence: t.recurrence,
-    created_at: t.createdAt,
-    updated_at: t.updatedAt,
-  };
-}
+import { serializeTask } from "@/lib/mcp/queries/tasks";
 
 export async function GET(request: NextRequest) {
   const userId = getUserId();
@@ -38,7 +19,6 @@ export async function GET(request: NextRequest) {
     let rows;
 
     if (taskDate === today) {
-      // Today: also include incomplete tasks from previous days
       const conditions = and(
         eq(tasks.userId, userId),
         or(eq(tasks.taskDate, taskDate), and(lt(tasks.taskDate, taskDate), eq(tasks.done, false))),

--- a/src/app/api/workouts/logs/[id]/route.ts
+++ b/src/app/api/workouts/logs/[id]/route.ts
@@ -5,32 +5,7 @@ import { eq, and } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
 import { updateWithVersion } from "@/lib/db/optimistic";
 import { conflictResponse } from "@/lib/api-conflict";
-
-function serializeLogExercise(e: typeof workoutLogExercises.$inferSelect) {
-  return {
-    id: e.id,
-    log_id: e.logId,
-    exercise_name: e.exerciseName,
-    exercise_type: e.exerciseType,
-    sort_order: e.sortOrder,
-    sets: e.sets,
-  };
-}
-
-function serializeLog(l: typeof workoutLogs.$inferSelect, exercises: typeof workoutLogExercises.$inferSelect[]) {
-  return {
-    id: l.id,
-    user_id: l.userId,
-    template_id: l.templateId,
-    name: l.name,
-    log_date: l.logDate,
-    duration_minutes: l.durationMinutes,
-    notes: l.notes,
-    created_at: l.createdAt,
-    updated_at: l.updatedAt,
-    workout_log_exercises: exercises.map(serializeLogExercise),
-  };
-}
+import { serializeLog } from "@/lib/mcp/queries/workouts";
 
 async function getLogWithExercises(id: string, userId: string) {
   const rows = await db

--- a/src/app/api/workouts/logs/route.ts
+++ b/src/app/api/workouts/logs/route.ts
@@ -3,32 +3,7 @@ import { db } from "@/lib/db/client";
 import { workoutLogs, workoutLogExercises } from "@/lib/db/schema";
 import { eq, and, gte, lte, desc, inArray } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeLogExercise(e: typeof workoutLogExercises.$inferSelect) {
-  return {
-    id: e.id,
-    log_id: e.logId,
-    exercise_name: e.exerciseName,
-    exercise_type: e.exerciseType,
-    sort_order: e.sortOrder,
-    sets: e.sets,
-  };
-}
-
-function serializeLog(l: typeof workoutLogs.$inferSelect, exercises: typeof workoutLogExercises.$inferSelect[]) {
-  return {
-    id: l.id,
-    user_id: l.userId,
-    template_id: l.templateId,
-    name: l.name,
-    log_date: l.logDate,
-    duration_minutes: l.durationMinutes,
-    notes: l.notes,
-    created_at: l.createdAt,
-    updated_at: l.updatedAt,
-    workout_log_exercises: exercises.map(serializeLogExercise),
-  };
-}
+import { serializeLog } from "@/lib/mcp/queries/workouts";
 
 export async function GET(request: NextRequest) {
   const userId = getUserId();

--- a/src/app/api/workouts/templates/[id]/route.ts
+++ b/src/app/api/workouts/templates/[id]/route.ts
@@ -3,32 +3,7 @@ import { db } from "@/lib/db/client";
 import { workoutTemplates, workoutExercises } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeExercise(e: typeof workoutExercises.$inferSelect) {
-  return {
-    id: e.id,
-    template_id: e.templateId,
-    name: e.name,
-    exercise_type: e.exerciseType,
-    sort_order: e.sortOrder,
-    default_sets: e.defaultSets,
-    default_reps: e.defaultReps,
-    default_weight: e.defaultWeight,
-    default_duration: e.defaultDuration,
-    notes: e.notes,
-  };
-}
-
-function serializeTemplate(t: typeof workoutTemplates.$inferSelect, exercises: typeof workoutExercises.$inferSelect[]) {
-  return {
-    id: t.id,
-    user_id: t.userId,
-    name: t.name,
-    description: t.description,
-    created_at: t.createdAt,
-    workout_exercises: exercises.map(serializeExercise),
-  };
-}
+import { serializeTemplate } from "@/lib/mcp/queries/workouts";
 
 async function getTemplateWithExercises(id: string, userId: string) {
   const rows = await db

--- a/src/app/api/workouts/templates/route.ts
+++ b/src/app/api/workouts/templates/route.ts
@@ -3,32 +3,7 @@ import { db } from "@/lib/db/client";
 import { workoutTemplates, workoutExercises } from "@/lib/db/schema";
 import { eq, desc, inArray } from "drizzle-orm";
 import { getUserId } from "@/lib/auth";
-
-function serializeExercise(e: typeof workoutExercises.$inferSelect) {
-  return {
-    id: e.id,
-    template_id: e.templateId,
-    name: e.name,
-    exercise_type: e.exerciseType,
-    sort_order: e.sortOrder,
-    default_sets: e.defaultSets,
-    default_reps: e.defaultReps,
-    default_weight: e.defaultWeight,
-    default_duration: e.defaultDuration,
-    notes: e.notes,
-  };
-}
-
-function serializeTemplate(t: typeof workoutTemplates.$inferSelect, exercises: typeof workoutExercises.$inferSelect[]) {
-  return {
-    id: t.id,
-    user_id: t.userId,
-    name: t.name,
-    description: t.description,
-    created_at: t.createdAt,
-    workout_exercises: exercises.map(serializeExercise),
-  };
-}
+import { serializeTemplate } from "@/lib/mcp/queries/workouts";
 
 export async function GET() {
   const userId = getUserId();

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -23,14 +23,14 @@ export const profiles = pgTable("profiles", {
   email: text("email").notNull(),
   displayName: text("display_name"),
   avatarUrl: text("avatar_url"),
-  timezone: text("timezone").default("UTC"),
+  timezone: text("timezone").notNull().default("UTC"),
   isAdmin: boolean("is_admin").notNull().default(false),
   aiModelConfig: jsonb("ai_model_config"),
   toolCallingEnabled: boolean("tool_calling_enabled").notNull().default(true),
   briefingEnabled: boolean("briefing_enabled").notNull().default(true),
   onboardedAt: timestamp("onboarded_at", { withTimezone: true }),
-  createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
-  updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
 });
 
 // ---------------------------------------------------------------------------
@@ -229,6 +229,7 @@ export const journalEntries = pgTable(
   },
   (t) => [
     index("idx_journal_user_date").on(t.userId, t.entryDate),
+    uniqueIndex("journal_entries_user_date_unique").on(t.userId, t.entryDate),
     index("idx_journal_search").using("gin", sql`to_tsvector('english', ${t.content})`),
     check("journal_mood_check", sql`${t.mood} >= 1 AND ${t.mood} <= 5`),
   ]
@@ -288,7 +289,10 @@ export const workoutLogs = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (t) => [index("idx_workout_logs_user_date").on(t.userId, t.logDate)]
+  (t) => [
+    index("idx_workout_logs_user_date").on(t.userId, t.logDate),
+    index("idx_workout_logs_template").on(t.templateId),
+  ]
 );
 
 export const workoutLogExercises = pgTable(
@@ -366,8 +370,8 @@ export const dailyBriefings = pgTable(
       .references(() => profiles.id, { onDelete: "cascade" }),
     briefingDate: date("briefing_date").notNull().defaultNow(),
     content: text("content").notNull(),
-    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
-    updatedAt: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     uniqueIndex("daily_briefings_user_date_unique").on(t.userId, t.briefingDate),
@@ -386,7 +390,7 @@ export const insightCache = pgTable(
       .references(() => profiles.id, { onDelete: "cascade" }),
     cacheDate: date("cache_date").notNull().defaultNow(),
     insights: jsonb("insights").notNull().default(sql`'[]'::jsonb`),
-    createdAt: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     uniqueIndex("insight_cache_user_date_unique").on(t.userId, t.cacheDate),

--- a/src/lib/mcp/db.ts
+++ b/src/lib/mcp/db.ts
@@ -1,1 +1,0 @@
-export { db } from "@/lib/db/client";

--- a/src/lib/mcp/queries/focus.ts
+++ b/src/lib/mcp/queries/focus.ts
@@ -4,6 +4,21 @@ import { eq, and, gte, lte, desc } from "drizzle-orm";
 import { QueryResult } from "@/lib/mcp/types";
 import { getToday } from "@/lib/dates";
 
+export function serializeSession(s: typeof focusSessions.$inferSelect) {
+  return {
+    id: s.id,
+    user_id: s.userId,
+    task_id: s.taskId,
+    duration_minutes: s.durationMinutes,
+    break_minutes: s.breakMinutes,
+    started_at: s.startedAt,
+    completed_at: s.completedAt,
+    status: s.status,
+    notes: s.notes,
+    updated_at: s.updatedAt,
+  };
+}
+
 export interface FocusSession {
   id: string;
   user_id: string;

--- a/src/lib/mcp/queries/goals.ts
+++ b/src/lib/mcp/queries/goals.ts
@@ -4,6 +4,24 @@ import { eq, and, asc, desc } from "drizzle-orm";
 import { QueryResult } from "@/lib/mcp/types";
 import { getToday } from "@/lib/dates";
 
+export function serializeGoal(g: typeof goals.$inferSelect) {
+  return {
+    id: g.id,
+    user_id: g.userId,
+    title: g.title,
+    description: g.description,
+    category: g.category,
+    status: g.status,
+    progress: g.progress,
+    progress_mode: g.progressMode,
+    target_date: g.targetDate,
+    completed_at: g.completedAt,
+    sort_order: g.sortOrder,
+    created_at: g.createdAt,
+    updated_at: g.updatedAt,
+  };
+}
+
 export interface Goal {
   id: string;
   user_id: string;

--- a/src/lib/mcp/queries/habits.ts
+++ b/src/lib/mcp/queries/habits.ts
@@ -5,6 +5,23 @@ import { QueryResult } from "@/lib/mcp/types";
 import { getToday } from "@/lib/dates";
 import { calculateStreak, getApplicableDays } from "@/lib/habit-stats";
 
+export function serializeHabit(h: typeof habits.$inferSelect) {
+  return {
+    id: h.id,
+    user_id: h.userId,
+    name: h.name,
+    description: h.description,
+    frequency: h.frequency,
+    target_days: h.targetDays,
+    color: h.color,
+    archived: h.archived,
+    sort_order: h.sortOrder,
+    goal_id: h.goalId,
+    created_at: h.createdAt,
+    updated_at: h.updatedAt,
+  };
+}
+
 export interface Habit {
   id: string;
   user_id: string;

--- a/src/lib/mcp/queries/journal.ts
+++ b/src/lib/mcp/queries/journal.ts
@@ -4,6 +4,18 @@ import { eq, and, desc, sql } from "drizzle-orm";
 import { QueryResult } from "@/lib/mcp/types";
 import { getToday } from "@/lib/dates";
 
+export function serializeEntry(e: typeof journalEntries.$inferSelect) {
+  return {
+    id: e.id,
+    user_id: e.userId,
+    entry_date: e.entryDate,
+    content: e.content,
+    mood: e.mood,
+    created_at: e.createdAt,
+    updated_at: e.updatedAt,
+  };
+}
+
 export interface JournalEntry {
   id: string;
   user_id: string;

--- a/src/lib/mcp/queries/spaces.ts
+++ b/src/lib/mcp/queries/spaces.ts
@@ -3,6 +3,20 @@ import { spaces } from "@/lib/db/schema";
 import { eq, and, desc } from "drizzle-orm";
 import { QueryResult } from "@/lib/mcp/types";
 
+export function serializeSpace(s: typeof spaces.$inferSelect) {
+  return {
+    id: s.id,
+    user_id: s.userId,
+    name: s.name,
+    description: s.description,
+    status: s.status,
+    progress: s.progress,
+    deadline: s.deadline,
+    created_at: s.createdAt,
+    updated_at: s.updatedAt,
+  };
+}
+
 export interface Space {
   id: string;
   user_id: string;

--- a/src/lib/mcp/queries/tags.ts
+++ b/src/lib/mcp/queries/tags.ts
@@ -1,0 +1,11 @@
+import { tags } from "@/lib/db/schema";
+
+export function serializeTag(t: typeof tags.$inferSelect) {
+  return {
+    id: t.id,
+    user_id: t.userId,
+    name: t.name,
+    color: t.color,
+    created_at: t.createdAt,
+  };
+}

--- a/src/lib/mcp/queries/tasks.ts
+++ b/src/lib/mcp/queries/tasks.ts
@@ -44,7 +44,7 @@ export interface UpdateTaskFields {
   sort_order?: number;
 }
 
-function rowToTask(row: typeof tasks.$inferSelect): Task {
+export function serializeTask(row: typeof tasks.$inferSelect): Task {
   return {
     id: row.id,
     user_id: row.userId,
@@ -62,6 +62,27 @@ function rowToTask(row: typeof tasks.$inferSelect): Task {
     created_at: row.createdAt.toISOString(),
     updated_at: row.updatedAt.toISOString(),
   };
+}
+
+export function getNextOccurrence(taskDate: string, recurrence: { type: string; days?: number[] }): string {
+  const d = new Date(taskDate + "T00:00:00");
+  switch (recurrence.type) {
+    case "daily":
+      d.setDate(d.getDate() + 1);
+      break;
+    case "weekdays": {
+      d.setDate(d.getDate() + 1);
+      while (d.getDay() === 0 || d.getDay() === 6) d.setDate(d.getDate() + 1);
+      break;
+    }
+    case "weekly":
+      d.setDate(d.getDate() + 7);
+      break;
+    case "monthly":
+      d.setMonth(d.getMonth() + 1);
+      break;
+  }
+  return d.toISOString().split("T")[0];
 }
 
 export async function getTasksForDate(
@@ -87,7 +108,7 @@ export async function getTasksForDate(
         )
         .orderBy(asc(tasks.priority), asc(tasks.sortOrder));
 
-      return { data: rows.map(rowToTask), error: null };
+      return { data: rows.map(serializeTask), error: null };
     }
 
     const rows = await db
@@ -96,7 +117,7 @@ export async function getTasksForDate(
       .where(and(eq(tasks.userId, userId), eq(tasks.taskDate, taskDate)))
       .orderBy(asc(tasks.priority), asc(tasks.sortOrder));
 
-    return { data: rows.map(rowToTask), error: null };
+    return { data: rows.map(serializeTask), error: null };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
   }
@@ -116,7 +137,7 @@ export async function getOverdueTasks(
       )
       .orderBy(asc(tasks.priority), asc(tasks.sortOrder));
 
-    return { data: rows.map(rowToTask), error: null };
+    return { data: rows.map(serializeTask), error: null };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
   }
@@ -144,7 +165,7 @@ export async function createTask(
       })
       .returning();
 
-    return { data: rowToTask(row), error: null };
+    return { data: serializeTask(row), error: null };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
   }
@@ -181,7 +202,7 @@ export async function updateTask(
       .returning();
 
     if (!row) return { data: null, error: "Task not found" };
-    return { data: rowToTask(row), error: null };
+    return { data: serializeTask(row), error: null };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
   }
@@ -199,7 +220,7 @@ export async function completeTask(
       .returning();
 
     if (!row) return { data: null, error: "Task not found" };
-    return { data: rowToTask(row), error: null };
+    return { data: serializeTask(row), error: null };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
   }

--- a/src/lib/mcp/queries/workouts.ts
+++ b/src/lib/mcp/queries/workouts.ts
@@ -3,6 +3,58 @@ import { workoutLogs, workoutLogExercises, workoutTemplates, workoutExercises } 
 import { eq, and, gte, lte, desc, inArray } from "drizzle-orm";
 import { QueryResult } from "@/lib/mcp/types";
 
+export function serializeLogExercise(e: typeof workoutLogExercises.$inferSelect) {
+  return {
+    id: e.id,
+    log_id: e.logId,
+    exercise_name: e.exerciseName,
+    exercise_type: e.exerciseType,
+    sort_order: e.sortOrder,
+    sets: e.sets,
+  };
+}
+
+export function serializeLog(l: typeof workoutLogs.$inferSelect, exercises: typeof workoutLogExercises.$inferSelect[]) {
+  return {
+    id: l.id,
+    user_id: l.userId,
+    template_id: l.templateId,
+    name: l.name,
+    log_date: l.logDate,
+    duration_minutes: l.durationMinutes,
+    notes: l.notes,
+    created_at: l.createdAt,
+    updated_at: l.updatedAt,
+    workout_log_exercises: exercises.map(serializeLogExercise),
+  };
+}
+
+export function serializeExercise(e: typeof workoutExercises.$inferSelect) {
+  return {
+    id: e.id,
+    template_id: e.templateId,
+    name: e.name,
+    exercise_type: e.exerciseType,
+    sort_order: e.sortOrder,
+    default_sets: e.defaultSets,
+    default_reps: e.defaultReps,
+    default_weight: e.defaultWeight,
+    default_duration: e.defaultDuration,
+    notes: e.notes,
+  };
+}
+
+export function serializeTemplate(t: typeof workoutTemplates.$inferSelect, exercises: typeof workoutExercises.$inferSelect[]) {
+  return {
+    id: t.id,
+    user_id: t.userId,
+    name: t.name,
+    description: t.description,
+    created_at: t.createdAt,
+    workout_exercises: exercises.map(serializeExercise),
+  };
+}
+
 export interface WorkoutLogExercise {
   id: string;
   log_id: string;
@@ -152,7 +204,6 @@ export async function getWorkoutTemplates(
     if (templates.length === 0) return { data: [], error: null };
 
     const templateIds = templates.map((t) => t.id);
-    const { inArray } = await import("drizzle-orm");
     const exercises = await db
       .select()
       .from(workoutExercises)

--- a/src/lib/mcp/resources/briefings.ts
+++ b/src/lib/mcp/resources/briefings.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getTodayBriefing } from "@/lib/mcp/queries/briefings";
 import type { Extra } from "@/lib/mcp/tools/helpers";
 
@@ -13,9 +13,10 @@ export function registerBriefingResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("briefing:read")) {
+      const scopeError = checkScope(auth.scopes, "briefing:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: briefing:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/calendar.ts
+++ b/src/lib/mcp/resources/calendar.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getDaySummary, getWeekSummary } from "@/lib/mcp/queries/calendar";
 import { getToday } from "@/lib/dates";
 import type { Extra } from "@/lib/mcp/tools/helpers";
@@ -14,9 +14,10 @@ export function registerCalendarResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("calendar:read")) {
+      const scopeError = checkScope(auth.scopes, "calendar:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: calendar:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 
@@ -43,9 +44,10 @@ export function registerCalendarResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("calendar:read")) {
+      const scopeError = checkScope(auth.scopes, "calendar:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: calendar:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/focus.ts
+++ b/src/lib/mcp/resources/focus.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getTodayFocusStats } from "@/lib/mcp/queries/focus";
 import type { Extra } from "@/lib/mcp/tools/helpers";
 
@@ -13,9 +13,10 @@ export function registerFocusResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("focus:read")) {
+      const scopeError = checkScope(auth.scopes, "focus:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: focus:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/goals.ts
+++ b/src/lib/mcp/resources/goals.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getGoals } from "@/lib/mcp/queries/goals";
 import type { Extra } from "@/lib/mcp/tools/helpers";
 
@@ -13,9 +13,10 @@ export function registerGoalResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("goals:read")) {
+      const scopeError = checkScope(auth.scopes, "goals:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: goals:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/habits.ts
+++ b/src/lib/mcp/resources/habits.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import {
   getHabitsWithTodayStatus,
   getHabits,
@@ -18,9 +18,10 @@ export function registerHabitResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("habits:read")) {
+      const scopeError = checkScope(auth.scopes, "habits:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: habits:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 
@@ -47,9 +48,10 @@ export function registerHabitResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("habits:read")) {
+      const scopeError = checkScope(auth.scopes, "habits:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: habits:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/journal.ts
+++ b/src/lib/mcp/resources/journal.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getJournalEntry, getRecentJournalEntries } from "@/lib/mcp/queries/journal";
 import { getToday } from "@/lib/dates";
 import type { Extra } from "@/lib/mcp/tools/helpers";
@@ -14,9 +14,10 @@ export function registerJournalResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("journal:read")) {
+      const scopeError = checkScope(auth.scopes, "journal:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: journal:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 
@@ -43,9 +44,10 @@ export function registerJournalResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("journal:read")) {
+      const scopeError = checkScope(auth.scopes, "journal:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: journal:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/reviews.ts
+++ b/src/lib/mcp/resources/reviews.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getLatestReview } from "@/lib/mcp/queries/reviews";
 import type { Extra } from "@/lib/mcp/tools/helpers";
 
@@ -13,9 +13,10 @@ export function registerReviewResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("review:read")) {
+      const scopeError = checkScope(auth.scopes, "review:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: review:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/spaces.ts
+++ b/src/lib/mcp/resources/spaces.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getSpaces } from "@/lib/mcp/queries/spaces";
 import type { Extra } from "@/lib/mcp/tools/helpers";
 
@@ -13,9 +13,10 @@ export function registerSpaceResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("spaces:read")) {
+      const scopeError = checkScope(auth.scopes, "spaces:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: spaces:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/tasks.ts
+++ b/src/lib/mcp/resources/tasks.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getTasksForDate, getOverdueTasks } from "@/lib/mcp/queries/tasks";
 import type { Extra } from "@/lib/mcp/tools/helpers";
 
@@ -13,9 +13,10 @@ export function registerTaskResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("tasks:read")) {
+      const scopeError = checkScope(auth.scopes, "tasks:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: tasks:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 
@@ -42,9 +43,10 @@ export function registerTaskResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("tasks:read")) {
+      const scopeError = checkScope(auth.scopes, "tasks:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: tasks:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/resources/workouts.ts
+++ b/src/lib/mcp/resources/workouts.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getAuth } from "@/lib/mcp/tools/helpers";
+import { getAuth, checkScope } from "@/lib/mcp/tools/helpers";
 import { getWorkoutLogs } from "@/lib/mcp/queries/workouts";
 import { getToday, addDays } from "@/lib/dates";
 import type { Extra } from "@/lib/mcp/tools/helpers";
@@ -14,9 +14,10 @@ export function registerWorkoutResources(server: McpServer) {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };
 
-      if (!auth.scopes.includes("workouts:read")) {
+      const scopeError = checkScope(auth.scopes, "workouts:read");
+      if (scopeError) {
         return {
-          contents: [{ uri: uri.href, mimeType: "text/plain", text: "Insufficient scope: workouts:read" }],
+          contents: [{ uri: uri.href, mimeType: "text/plain", text: scopeError }],
         };
       }
 

--- a/src/lib/mcp/tools/focus.ts
+++ b/src/lib/mcp/tools/focus.ts
@@ -94,7 +94,7 @@ async function startFocusSession(
         userId,
         durationMinutes: args.duration_minutes,
         taskId: args.task_id ?? null,
-        breakMinutes: args.break_minutes ?? 5,
+        breakMinutes: args.break_minutes ?? 0,
         startedAt: new Date(),
         completedAt: null,
         status: "active",

--- a/src/lib/mcp/tools/goals.ts
+++ b/src/lib/mcp/tools/goals.ts
@@ -46,7 +46,7 @@ async function createGoal(
       .insert(goals)
       .values({
         userId,
-        title: args.title,
+        title: args.title.trim(),
         description: args.description ?? null,
         ...(args.category ? { category: args.category as "health" | "career" | "personal" | "financial" | "learning" | "relationships" | "other" } : {}),
         targetDate: args.target_date ?? null,

--- a/src/lib/mcp/tools/habits.ts
+++ b/src/lib/mcp/tools/habits.ts
@@ -2,10 +2,10 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db } from "@/lib/db/client";
 import { habits, habitLogs } from "@/lib/db/schema";
-import { eq, and, gte, lte, asc } from "drizzle-orm";
+import { eq, and, asc } from "drizzle-orm";
 import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, Extra } from "./helpers";
 import { dateSchema, habitFrequencySchema } from "./validators";
-import { calculateStreak, getApplicableDays } from "@/lib/habit-stats";
+import { getHabitStats } from "@/lib/mcp/queries/habits";
 
 // ---------------------------------------------------------------------------
 // Query helpers
@@ -19,61 +19,6 @@ async function getHabits(userId: string, includeArchived = false) {
 
     const rows = await db.select().from(habits).where(conditions).orderBy(asc(habits.createdAt));
     return { data: rows, error: null };
-  } catch (err) {
-    return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
-  }
-}
-
-async function getHabitStats(userId: string, habitId: string, days = 30) {
-  try {
-    const safeDays = Math.max(1, days);
-    const today = new Date();
-    const startDate = new Date(today);
-    startDate.setDate(today.getDate() - (safeDays - 1));
-    const startDateStr = startDate.toISOString().split("T")[0];
-    const endDateStr = today.toISOString().split("T")[0];
-
-    const habitRows = await db
-      .select({ id: habits.id, name: habits.name, color: habits.color, targetDays: habits.targetDays })
-      .from(habits)
-      .where(and(eq(habits.id, habitId), eq(habits.userId, userId)));
-
-    if (habitRows.length === 0) return { data: null, error: "Habit not found" };
-    const habit = habitRows[0];
-
-    const logRows = await db
-      .select({ logDate: habitLogs.logDate })
-      .from(habitLogs)
-      .where(
-        and(
-          eq(habitLogs.habitId, habitId),
-          gte(habitLogs.logDate, startDateStr),
-          lte(habitLogs.logDate, endDateStr)
-        )
-      );
-
-    const habitLogDates = logRows.map((l) => l.logDate);
-    const targetDays: number[] =
-      Array.isArray(habit.targetDays) && habit.targetDays.length > 0
-        ? habit.targetDays
-        : [1, 2, 3, 4, 5, 6, 7];
-
-    const streak = calculateStreak(habitLogDates, targetDays);
-    const applicableDays = getApplicableDays(startDate, today, targetDays);
-    const completionRate = applicableDays > 0 ? habitLogDates.length / applicableDays : 0;
-    const recentLogs = [...new Set(habitLogDates)].sort().reverse();
-
-    return {
-      data: {
-        id: habit.id,
-        name: habit.name,
-        color: habit.color ?? null,
-        streak,
-        completionRate: Math.min(1, completionRate),
-        recentLogs,
-      },
-      error: null,
-    };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
   }

--- a/src/lib/mcp/tools/habits.ts
+++ b/src/lib/mcp/tools/habits.ts
@@ -2,9 +2,10 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db } from "@/lib/db/client";
 import { habits, habitLogs } from "@/lib/db/schema";
-import { eq, and, gte, asc, desc } from "drizzle-orm";
+import { eq, and, gte, lte, asc } from "drizzle-orm";
 import { getAuth, checkScope, textResult, errorResult, NOT_AUTHENTICATED, Extra } from "./helpers";
 import { dateSchema, habitFrequencySchema } from "./validators";
+import { calculateStreak, getApplicableDays } from "@/lib/habit-stats";
 
 // ---------------------------------------------------------------------------
 // Query helpers
@@ -25,36 +26,51 @@ async function getHabits(userId: string, includeArchived = false) {
 
 async function getHabitStats(userId: string, habitId: string, days = 30) {
   try {
+    const safeDays = Math.max(1, days);
+    const today = new Date();
+    const startDate = new Date(today);
+    startDate.setDate(today.getDate() - (safeDays - 1));
+    const startDateStr = startDate.toISOString().split("T")[0];
+    const endDateStr = today.toISOString().split("T")[0];
+
     const habitRows = await db
-      .select()
+      .select({ id: habits.id, name: habits.name, color: habits.color, targetDays: habits.targetDays })
       .from(habits)
       .where(and(eq(habits.id, habitId), eq(habits.userId, userId)));
 
     if (habitRows.length === 0) return { data: null, error: "Habit not found" };
     const habit = habitRows[0];
 
-    const fromDate = new Date();
-    fromDate.setDate(fromDate.getDate() - days);
-    const fromStr = fromDate.toISOString().split("T")[0];
-
-    const logs = await db
-      .select()
+    const logRows = await db
+      .select({ logDate: habitLogs.logDate })
       .from(habitLogs)
-      .where(and(eq(habitLogs.habitId, habitId), gte(habitLogs.logDate, fromStr)))
-      .orderBy(desc(habitLogs.logDate));
+      .where(
+        and(
+          eq(habitLogs.habitId, habitId),
+          gte(habitLogs.logDate, startDateStr),
+          lte(habitLogs.logDate, endDateStr)
+        )
+      );
 
-    const completedDays = logs.length;
-    const completionRate = days > 0 ? Math.round((completedDays / days) * 100) : 0;
+    const habitLogDates = logRows.map((l) => l.logDate);
+    const targetDays: number[] =
+      Array.isArray(habit.targetDays) && habit.targetDays.length > 0
+        ? habit.targetDays
+        : [1, 2, 3, 4, 5, 6, 7];
+
+    const streak = calculateStreak(habitLogDates, targetDays);
+    const applicableDays = getApplicableDays(startDate, today, targetDays);
+    const completionRate = applicableDays > 0 ? habitLogDates.length / applicableDays : 0;
+    const recentLogs = [...new Set(habitLogDates)].sort().reverse();
 
     return {
       data: {
-        habit,
-        logs,
-        stats: {
-          completedDays,
-          totalDays: days,
-          completionRate,
-        },
+        id: habit.id,
+        name: habit.name,
+        color: habit.color ?? null,
+        streak,
+        completionRate: Math.min(1, completionRate),
+        recentLogs,
       },
       error: null,
     };

--- a/src/lib/mcp/tools/journal.ts
+++ b/src/lib/mcp/tools/journal.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { db } from "@/lib/db/client";
 import { journalEntries } from "@/lib/db/schema";
-import { eq, and, gte, lte, desc, ilike } from "drizzle-orm";
+import { eq, and, gte, lte, desc, sql } from "drizzle-orm";
 import { getAuth, checkScope, textResult, errorResult, conflictResult, NOT_AUTHENTICATED, Extra } from "./helpers";
 import { dateSchema } from "./validators";
 import { updateWithVersion } from "@/lib/db/optimistic";
@@ -71,7 +71,7 @@ async function searchJournal(userId: string, query: string) {
       .where(
         and(
           eq(journalEntries.userId, userId),
-          ilike(journalEntries.content, `%${query}%`)
+          sql`to_tsvector('english', ${journalEntries.content}) @@ plainto_tsquery('english', ${query})`
         )
       )
       .orderBy(desc(journalEntries.entryDate))
@@ -100,13 +100,13 @@ async function createOrUpdateJournalEntry(
       .values({
         userId,
         entryDate,
-        content: args.content,
+        content: args.content.trim(),
         mood: args.mood ?? null,
       })
       .onConflictDoUpdate({
         target: [journalEntries.userId, journalEntries.entryDate],
         set: {
-          content: args.content,
+          content: args.content.trim(),
           mood: args.mood ?? null,
           updatedAt: new Date(),
         },

--- a/src/lib/mcp/tools/spaces.ts
+++ b/src/lib/mcp/tools/spaces.ts
@@ -36,8 +36,8 @@ async function createSpace(
       .insert(spaces)
       .values({
         userId,
-        name: args.name,
-        description: args.description ?? null,
+        name: args.name.trim(),
+        description: args.description?.trim() ?? null,
         status: "active",
       })
       .returning();
@@ -53,8 +53,8 @@ function buildSpacePatch(args: {
   status?: string;
 }): Partial<typeof spaces.$inferInsert> {
   const patch: Partial<typeof spaces.$inferInsert> = {};
-  if (args.name !== undefined) patch.name = args.name;
-  if (args.description !== undefined) patch.description = args.description;
+  if (args.name !== undefined) patch.name = args.name.trim();
+  if (args.description !== undefined) patch.description = args.description?.trim();
   if (args.status !== undefined) patch.status = args.status as "active" | "paused" | "completed";
   return patch;
 }
@@ -112,7 +112,7 @@ export function registerSpaceTools(server: McpServer) {
     "create_space",
     "Create a new space (project) to organize tasks",
     {
-      name: z.string().describe("Space name"),
+      name: z.string().min(1).describe("Space name"),
       description: z.string().optional().describe("Space description"),
     },
     async (args, extra: Extra) => {

--- a/src/lib/mcp/tools/tasks.ts
+++ b/src/lib/mcp/tools/tasks.ts
@@ -294,6 +294,7 @@ export function registerTaskTools(server: McpServer) {
           priority: row.priority,
           taskDate: nextDate,
           spaceId: row.spaceId,
+          goalId: row.goalId,
           recurrence: row.recurrence,
           sortOrder: row.sortOrder,
         });

--- a/src/lib/mcp/tools/tasks.ts
+++ b/src/lib/mcp/tools/tasks.ts
@@ -6,6 +6,7 @@ import { eq, and, or, lt, asc } from "drizzle-orm";
 import { getAuth, checkScope, textResult, errorResult, conflictResult, NOT_AUTHENTICATED, Extra } from "./helpers";
 import { dateSchema, prioritySchema, priorityDescription } from "./validators";
 import { updateWithVersion } from "@/lib/db/optimistic";
+import { getNextOccurrence } from "@/lib/mcp/queries/tasks";
 
 // ---------------------------------------------------------------------------
 // Query helpers
@@ -261,6 +262,8 @@ export function registerTaskTools(server: McpServer) {
       const scopeError = checkScope(auth.scopes, "tasks:write");
       if (scopeError) return errorResult(scopeError);
 
+      let row: typeof tasks.$inferSelect | null = null;
+
       if (args.expected_updated_at) {
         const result = await updateWithVersion<typeof tasks.$inferSelect>({
           table: tasks,
@@ -269,16 +272,34 @@ export function registerTaskTools(server: McpServer) {
           expectedUpdatedAt: args.expected_updated_at,
           patch: { done: true, doneAt: new Date() },
         });
-        if (result.ok) return textResult(result.row);
-        if (result.reason === "not_found") return errorResult("Task not found");
-        if (result.reason === "invalid_token") return errorResult("Invalid expected_updated_at");
-        return conflictResult(result.current);
+        if (!result.ok) {
+          if (result.reason === "not_found") return errorResult("Task not found");
+          if (result.reason === "invalid_token") return errorResult("Invalid expected_updated_at");
+          return conflictResult(result.current);
+        }
+        row = result.row;
+      } else {
+        const result = await completeTaskLegacy(auth.userId, args.task_id);
+        if (result.error) return errorResult(`Error: ${result.error}`);
+        row = result.data;
       }
 
-      const result = await completeTaskLegacy(auth.userId, args.task_id);
-      if (result.error) return errorResult(`Error: ${result.error}`);
+      if (row?.recurrence && row.taskDate) {
+        const recurrence = row.recurrence as { type: string; days?: number[] };
+        const nextDate = getNextOccurrence(row.taskDate, recurrence);
+        await db.insert(tasks).values({
+          userId: auth.userId,
+          title: row.title,
+          notes: row.notes,
+          priority: row.priority,
+          taskDate: nextDate,
+          spaceId: row.spaceId,
+          recurrence: row.recurrence,
+          sortOrder: row.sortOrder,
+        });
+      }
 
-      return textResult(result.data);
+      return textResult(row);
     }
   );
 

--- a/src/lib/mcp/tools/workouts.ts
+++ b/src/lib/mcp/tools/workouts.ts
@@ -145,10 +145,11 @@ async function logWorkout(
       .returning();
 
     if (exercises.length > 0) {
-      const exerciseRows = exercises.map((ex) => ({
+      const exerciseRows = exercises.map((ex, i) => ({
         logId: log.id,
         exerciseName: ex.name,
         exerciseType: ex.type ?? "strength",
+        sortOrder: i,
         sets:
           ex.sets != null
             ? Array.from({ length: ex.sets }, () => ({

--- a/src/lib/mcp/types.ts
+++ b/src/lib/mcp/types.ts
@@ -1,13 +1,3 @@
-import type { db } from "@/lib/db/client";
-import { AuthResult } from "@/lib/token-validation";
-
-/** Context available to every MCP tool/resource/prompt handler */
-export interface McpContext {
-  userId: string;
-  db: typeof db;
-  auth: AuthResult;
-}
-
 /** Standard query result shape */
 export interface QueryResult<T> {
   data: T | null;

--- a/src/lib/oauth-scopes.ts
+++ b/src/lib/oauth-scopes.ts
@@ -36,10 +36,6 @@ export const OAUTH_SCOPES: ScopeDefinition[] = [
   { scope: "spaces:read", label: "Read your spaces", description: "View spaces and their details", category: "Spaces" },
   { scope: "spaces:write", label: "Manage your spaces", description: "Create and update spaces", category: "Spaces" },
 
-  // Profile
-  { scope: "profile:read", label: "Read your profile", description: "View profile and settings", category: "Profile" },
-  { scope: "profile:write", label: "Update your profile", description: "Modify profile settings", category: "Profile" },
-
   // Calendar
   { scope: "calendar:read", label: "Read your calendar", description: "View daily and weekly summaries", category: "Calendar" },
 

--- a/src/lib/token-validation.ts
+++ b/src/lib/token-validation.ts
@@ -94,15 +94,6 @@ export async function validateMcpAuth(
 }
 
 /**
- * Check if the authenticated user has the required scope.
- */
-export function hasScope(auth: AuthResult, requiredScope: string): boolean {
-  // If they have the expanded "all" scopes, they have everything
-  // The expandScopes function already handled "all" → individual scopes
-  return auth.scopes.includes(requiredScope);
-}
-
-/**
  * Build a WWW-Authenticate header value per RFC 6750.
  */
 function buildWwwAuthenticate(error?: string, errorDescription?: string): string {


### PR DESCRIPTION
## Summary

Systematic 12-section code review of the repo per `tasks/code-review-plan.md`. Each section: audit → fix → verify. Full findings in `tasks/review-findings.md`.

**Foundations (1–4):**
- Cleaned up auth surface: removed dead `hasScope()`, orphan `profile:*` scopes, unified resource scope checks to use `checkScope()` helper
- Hardened schema: unique index on `journal_entries (user_id, entry_date)`, missing FK index on `workout_logs.template_id`, made timestamps/`profiles.timezone` NOT NULL (migration `0004_silent_prima.sql`)
- Removed dead MCP shell code: unused `McpContext` type, orphaned `src/lib/mcp/db.ts` re-export
- Aligned compose files: added `SELF_HOSTED_USER_EMAIL` to from-source compose, removed redundant `NODE_ENV`

**Domain verticals (5–12):**
- Deduplicated per-domain serializers (tasks, habits, journal, workouts, focus, goals, spaces, tags) into shared `src/lib/mcp/queries/*.ts` modules
- Fixed bugs:
  - `rollover` didn't set `doneAt`/`updatedAt` on originals
  - `reorder` didn't set `updatedAt` on reordered tasks
  - MCP `complete_task` didn't spawn next occurrence for recurring tasks
  - MCP `get_habit_stats` used wrong denominator (all calendar days vs. target days)
  - MCP `search_journal` used `ilike` substring match instead of full-text search
  - MCP `log_workout` didn't set `sortOrder` on exercises
  - Tag POST accepted whitespace-only names; tag PATCH accepted empty trimmed names
  - MCP space/create didn't trim or enforce min length
- Aligned inconsistencies: MCP `break_minutes` default (5→0), MCP goal/habit/space title trimming

**Pre-merge review pass:**
- Caught surviving duplicate of `getHabitStats` in `tools/habits.ts` — consolidated to shared version
- Caught `complete_task` recurring-spawn dropping `goalId` — now preserved
- Caught `api/spaces/[id]` PATCH missing trim/empty-reject (tags PATCH had it) — aligned

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean
- [x] `npm test` — 93 tests passing
- [ ] Spot-check dashboard after deploy: tasks/habits/journal/workouts/focus/goals/spaces pages render and CRUD works
- [ ] Verify migration `0004_silent_prima.sql` applies cleanly on the VPS (entrypoint auto-runs it on container start)
- [ ] Verify MCP `get_habit_stats` returns the new focused shape (`{ id, name, color, streak, completionRate, recentLogs }`) — OpenClaw consumers may need to update if they read old fields
- [ ] Verify MCP `search_journal` returns full-text-ranked results instead of substring matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)