### PR TITLE
Fix install flow: use :latest image tag, make Postgres host port opt-in

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -16,8 +16,11 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-dailyagent}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dailyagent}
       POSTGRES_DB: ${POSTGRES_DB:-dailyagent}
-    ports:
-      - "127.0.0.1:5432:5432"
+    # The app container reaches Postgres over the internal Docker network,
+    # so you don't need to publish 5432 on the host. Uncomment only if you
+    # want to connect from the host (e.g. with `psql` or a GUI client).
+    # ports:
+    #   - "127.0.0.1:5432:5432"
     volumes:
       - dailyagent_pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -27,9 +30,11 @@ services:
       retries: 5
 
   app:
-    # Pin to a major version (:v1) for safe auto-upgrades, or use :latest.
-    # Alternatives: docker.io/walrusquant/mcp-dailyagent:v1
-    image: ghcr.io/walrusquant/mcp-dailyagent:v1
+    # Tracks the latest build from `main`. Once a semver release (e.g. v1.0.0)
+    # is published, you can pin to `:v1` for safe auto-upgrades within a major
+    # version, or `:v1.0.0` for an exact pin.
+    # Alternatives: docker.io/walrusquant/mcp-dailyagent:latest
+    image: ghcr.io/walrusquant/mcp-dailyagent:latest
     container_name: dailyagent-app
     restart: unless-stopped
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,11 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-dailyagent}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dailyagent}
       POSTGRES_DB: ${POSTGRES_DB:-dailyagent}
-    ports:
-      - "127.0.0.1:5432:5432"
+    # The app container reaches Postgres over the internal Docker network,
+    # so you don't need to publish 5432 on the host. Uncomment only if you
+    # want to connect from the host (e.g. with `psql` or a GUI client).
+    # ports:
+    #   - "127.0.0.1:5432:5432"
     volumes:
       - dailyagent_pgdata:/var/lib/postgresql/data
     healthcheck:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -110,16 +110,16 @@ That's it. Migrations run automatically on container start.
 Pulled by default from GHCR:
 
 ```
-ghcr.io/walrusquant/mcp-dailyagent:v1
+ghcr.io/walrusquant/mcp-dailyagent:latest
 ```
 
 Mirrored to Docker Hub if you prefer:
 
 ```
-docker.io/walrusquant/mcp-dailyagent:v1
+docker.io/walrusquant/mcp-dailyagent:latest
 ```
 
-Available tags: `:latest`, `:v1`, `:v1.2`, `:v1.2.3`, `:sha-<short>`. Pin to `:v1` for safe auto-upgrades within the major version.
+Available tags: `:latest` (tracks `main`) and `:sha-<short>` for an exact commit pin. Once a semver release is cut, floating tags like `:v1`, `:v1.2`, and exact pins like `:v1.2.3` will also be published — pin to `:v1` for safe auto-upgrades within the major version.
 
 ## What next
 


### PR DESCRIPTION
## Summary

Fixes the two install failures reported in #5 by @kovs705:

- **Image tag 404.** `docker-compose.example.yml` pinned `ghcr.io/walrusquant/mcp-dailyagent:v1`, but no semver release has been tagged yet — the GHA workflow only publishes `:latest` (on `main`) and `:sha-<short>` today. `:v1` only materializes once a `v*.*.*` tag is pushed. Switched the example (and `docs/quick-start.md`) to `:latest` and added a comment pointing at `:v1` for later, once a release is cut.
- **Postgres host port collision.** Both compose files published `127.0.0.1:5432:5432`, which collided with any existing Postgres on the user's host (broke the Pi 5 install). The `app` container reaches Postgres over the internal Docker network, so the host mapping isn't needed by default. Commented it out in both `docker-compose.example.yml` and `docker-compose.yml` with a note explaining when to uncomment (e.g. `psql` from the host).

## Test plan

- [ ] On a clean host: `curl -o docker-compose.yml .../docker-compose.example.yml && curl -o .env .../.env.example && docker compose up -d` — should pull `:latest` and start cleanly without needing to rewrite the image tag.
- [ ] On a host with Postgres already running on 5432: same flow — no port-binding error.
- [ ] Opt-in host access: uncomment the `ports:` block, `docker compose up -d`, `psql -h 127.0.0.1 -U dailyagent` connects.
- [ ] `docs/quick-start.md` — render the updated "Image sources" section and confirm it reads correctly.

Closes #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)