### PR TITLE
ci: bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -27,8 +27,8 @@ jobs:
       OPENROUTER_API_KEY: "test-key"
       SIGNUP_SECRET: "test"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,30 +15,30 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up QEMU (for multi-arch)
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Compute tags and labels
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -52,7 +52,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,10 +32,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -48,7 +48,7 @@ jobs:
         run: cp -r landing/. site/
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./site
 
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## What

Bumps every GitHub Action across all three workflows (`Publish Docker image`, `CI`, `Docs`) to its current major that runs on **Node.js 24**.

## Why

While reviewing CI history, the **Jun 2** `v2.0.0` Publish Docker image run carried 3 annotations. Two were a transient Docker Hub registry timeout that already self-healed on the automatic retry (attempt #2 succeeded — nothing code-related). The third is a real, dated action item:

> Node.js 20 actions are deprecated. Actions will be **forced to run on Node.js 24 starting June 16th, 2026**, and Node 20 will be **removed from runners on September 16th, 2026**.

Every workflow was pinned to Node 20-era majors, so this warning fires on each run and the forced cutover is imminent.

## Changes

| Action | Before | After |
|--------|--------|-------|
| actions/checkout | v4 | v5 |
| actions/setup-node | v4 | v5 |
| actions/setup-python | v5 | v6 |
| docker/setup-qemu-action | v3 | v4 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v6 | v7 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

`upload-pages-artifact` and `deploy-pages` are bumped in lockstep to v5 to avoid a Pages artifact version mismatch.

## Notes

- No workflow logic, inputs, or step ordering changed — version bumps only. The usage patterns here are stable across these majors.
- The Docker Hub timeout that triggered the Jun 2 failure email needs **no fix** — it was an upstream registry blip and the publish already succeeded on retry. I deliberately did **not** bolt a third-party retry wrapper around the composite `docker/*` steps, since those can't be cleanly wrapped and it would add supply-chain surface for a rare, self-healing flake.

## Verifying

Merging runs `CI` + `Docker` on `main`; the deprecation annotations should be gone and all jobs green. `Docs` runs on its next docs-path change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)