### PR TITLE
docs: document the 11 new MCP tools (v2.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Not a chatbot. Not an AI product. Just a durable store for tasks, habits, journa
 
 Two front doors, one database:
 
-1. **MCP server** (`/api/mcp`) — the primary interface. Your OpenClaw agent reads and writes every piece of productivity data through it: 34 typed tools, a dozen prompt templates, a handful of read-only resources. Authenticated by a single bearer token.
+1. **MCP server** (`/api/mcp`) — the primary interface. Your OpenClaw agent reads and writes every piece of productivity data through it: 45 typed tools, a dozen prompt templates, a handful of read-only resources. Authenticated by a single bearer token.
 2. **Dashboard** (`/dashboard`, `/tasks`, `/habits`, `/journal`, `/workouts`, `/focus`, `/goals`, `/calendar`, `/review`, `/spaces`, `/settings`) — a Next.js UI for browsing and manually editing the same data. No AI features. No generate buttons. If you want AI, you talk to OpenClaw.
 
 OpenClaw owns everything about the agent: model choice, scheduling, message delivery (Telegram / WhatsApp / etc.), briefings, insights, reviews. This repo owns storage and the contract.
@@ -190,7 +190,7 @@ src/
     mcp/
       server.ts           # Factory: registers tools, prompts, resources
       auth.ts             # Bearer token validation
-      tools/              # 34 tools, one file per domain
+      tools/              # 45 tools, one file per domain
       prompts/            # 13 prompt templates
       resources/          # Read-only URI resources
       queries/            # Shared query helpers

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ flowchart TD
     API -->|Drizzle| DB
 ```
 
-- **MCP server** (`/api/mcp`) — the agent's interface. 34 typed tools for reading and writing every piece of productivity data, 13 prompt templates, plus read-only resources. Bearer-token authenticated.
+- **MCP server** (`/api/mcp`) — the agent's interface. 45 typed tools for reading and writing every piece of productivity data, 13 prompt templates, plus read-only resources. Bearer-token authenticated.
 - **Dashboard** — a Next.js UI for browsing and manually editing the same data. No AI features. No generate buttons. Just CRUD.
 
 OpenClaw owns model choice, scheduling, message delivery (Telegram / WhatsApp / etc.), briefings, insights, and reviews. This repo owns storage and the contract.
@@ -66,7 +66,7 @@ You if:
 
     ---
 
-    34 tools, grouped by domain, with input schemas and examples.
+    45 tools, grouped by domain, with input schemas and examples.
 
     [:octicons-arrow-right-24: Browse tools](mcp-reference.md)
 

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -107,7 +107,7 @@ curl -s -X POST \
   http://localhost:3000/api/mcp
 ```
 
-You should see a JSON-RPC response listing the server's capabilities and 34 tools.
+You should see a JSON-RPC response listing the server's capabilities and 45 tools.
 
 List tasks:
 

--- a/docs/mcp-reference.md
+++ b/docs/mcp-reference.md
@@ -1,6 +1,6 @@
 # MCP reference
 
-34 tools across 11 domains, plus 13 prompt templates and a handful of read-only resources. All served from `POST /api/mcp` over [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports), stateless, authenticated by `Authorization: Bearer <MCP_API_KEY>`.
+45 tools across 11 domains, plus 13 prompt templates and a handful of read-only resources. All served from `POST /api/mcp` over [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports), stateless, authenticated by `Authorization: Bearer <MCP_API_KEY>`.
 
 There's also a companion `GET /api/mcp/health` — **unauthenticated**, returns `{ ok, transport, tools, prompts, resources, version }`. Use it to confirm the server is up and speaking the right protocol before troubleshooting auth, and to discover how many tools the running build exposes.
 
@@ -9,6 +9,9 @@ There's also a companion `GET /api/mcp/health` — **unauthenticated**, returns 
 
 !!! note "Rate limit"
     `/api/mcp` is protected by an abuse-guard token-bucket rate limit (burst 100, refill 10/sec ≈ 600 req/min). Normal agent traffic never trips it; a runaway loop gets a `429 rate_limited` with a `Retry-After` header.
+
+!!! note "Optimistic concurrency"
+    The `update_*` tools — plus `complete_task`, `complete_focus_session`, `pause_focus_session`, `resume_focus_session`, and `create_journal_entry` when updating — accept an optional `expected_updated_at` (the ISO timestamp from your last read of that row). If set and the row changed in the meantime, the write fails with a `conflict` result (returning the current row) instead of clobbering it. Omit it for last-write-wins.
 
 ## Shared value formats
 
@@ -23,6 +26,7 @@ There's also a companion `GET /api/mcp/health` — **unauthenticated**, returns 
 | Space status | enum | `active`, `paused`, `completed` |
 | Mood | int `1-5` | 1 = low, 5 = great |
 | Exercise type | enum | `strength`, `timed`, `cardio` |
+| Focus status | enum | `active`, `paused`, `completed`, `cancelled` |
 | Focus duration | int `1-480` min | — |
 | Focus break | int `0-120` min | — |
 
@@ -103,6 +107,22 @@ Idempotent — toggles whether the habit was completed on the given date.
 | `habit_id` | UUID | yes | |
 | `date` | date | no | Defaults to today |
 
+### `update_habit`
+
+Update a habit's details, or archive/restore it.
+
+| Arg | Type | Required | Notes |
+|---|---|---|---|
+| `habit_id` | UUID | yes | |
+| `name`, `description`, `color` | varies | no | |
+| `frequency` | `daily \| weekly` | no | |
+| `target_days` | `int[1-7][]` | no | ISO weekdays |
+| `archived` | boolean | no | `true` hides it from `list_habits` (unless `include_archived`); `false` restores |
+
+### `delete_habit`
+
+Delete a habit permanently, including all its completion logs. To keep history, archive it via `update_habit` instead. Argument: `habit_id` (UUID).
+
 ---
 
 ## Journal
@@ -119,7 +139,7 @@ Fetch a single day or a date range.
 
 ### `search_journal`
 
-Substring search across all entries.
+Full-text search across entry content (Postgres `to_tsvector`/`plainto_tsquery`, English stemming).
 
 Argument: `query: string`.
 
@@ -132,6 +152,10 @@ Upserts — if an entry already exists for that date, it's overwritten.
 | `content` | string | yes |
 | `entry_date` | date | no (defaults today) |
 | `mood` | int `1-5` | no |
+
+### `delete_journal_entry`
+
+Delete the entry for a given date permanently. Argument: `entry_date` (date).
 
 ---
 
@@ -178,6 +202,52 @@ Each exercise entry:
 
 `type` must be one of `strength`, `timed`, `cardio`. `name` is required on each entry.
 
+### `create_workout_template`
+
+Save a reusable routine. The `exercises` argument is a **JSON string** array of template exercise entries.
+
+| Arg | Type | Required |
+|---|---|---|
+| `name` | string | yes |
+| `description` | string | no |
+| `exercises` | JSON string | no |
+
+Each template exercise entry:
+
+```json
+{
+  "name": "Bench Press",
+  "type": "strength",
+  "default_sets": 3,
+  "default_reps": 8,
+  "default_weight": 80,
+  "default_duration_seconds": null,
+  "notes": null
+}
+```
+
+### `update_workout_log`
+
+Update a logged workout. Only the fields you pass change. Passing `exercises` **replaces** the full exercise list (use `[]` to clear); omit it to leave the existing exercises untouched.
+
+| Arg | Type | Required |
+|---|---|---|
+| `log_id` | UUID | yes |
+| `name`, `notes` | string | no |
+| `log_date` | date | no |
+| `duration_minutes` | int | no |
+| `exercises` | JSON string | no |
+
+The `exercises` entry shape matches `log_workout` (with `sets`/`reps`/`weight`/`duration_seconds`).
+
+### `delete_workout_log`
+
+Delete a workout log permanently (also removes its logged exercises). Argument: `log_id` (UUID).
+
+### `delete_workout_template`
+
+Delete a template permanently. Its exercises are removed; past logs created from it are kept (their `template_id` is set to null). Argument: `template_id` (UUID).
+
 ---
 
 ## Focus sessions
@@ -203,6 +273,14 @@ No arguments. Returns today's totals (sessions started, completed, total focus m
 ### `complete_focus_session`
 
 Mark a session complete. Argument: `session_id: UUID`.
+
+### `pause_focus_session`
+
+Pause an in-progress session (sets status to `paused`). Resume later with `resume_focus_session`. Argument: `session_id` (UUID).
+
+### `resume_focus_session`
+
+Resume a paused session (sets status back to `active`). Argument: `session_id` (UUID).
 
 ---
 
@@ -237,6 +315,10 @@ Just update the progress %.
 | `goal_id` | UUID | yes |
 | `progress` | int `0-100` | yes |
 
+### `delete_goal`
+
+Delete a goal permanently, including its progress logs. To keep the record, set its status to `abandoned` via `update_goal` instead. Argument: `goal_id` (UUID).
+
 ---
 
 ## Spaces (projects)
@@ -259,6 +341,10 @@ No arguments.
 | `space_id` | UUID | yes | |
 | `name`, `description` | string | no | |
 | `status` | space status | no | `active`, `paused`, or `completed` |
+
+### `delete_space`
+
+Delete a space permanently. Tasks linked to it are kept but unlinked (their space becomes empty). Argument: `space_id` (UUID).
 
 ---
 
@@ -373,5 +459,5 @@ All tool errors come back as `text/plain` content starting with `Error: ` and th
 
 - **Validation errors** — Zod schema rejection. The message names the field and expected format.
 - **CHECK constraint failures** — DB-level rejection. Surfaces the Postgres error message; usually means the tool schema and DB constraint got out of sync (shouldn't happen with current `validators.ts`, but file a bug if it does).
-- **Not found** — e.g. `Task not found` when updating/completing a task that doesn't exist or belongs to a different user.
+- **Not found** — e.g. `Task not found` when updating, completing, or deleting a row that doesn't exist or belongs to a different user. All `update_*` and `delete_*` tools report this consistently.
 - **Unauthorized** — missing or wrong bearer token. HTTP 401 before the tool even runs.

--- a/docs/openclaw-skill.md
+++ b/docs/openclaw-skill.md
@@ -35,6 +35,8 @@ The MCP server is already registered in the user's OpenClaw config as `cadence`.
 
 ## Tools
 
+> Most write tools that modify an existing row accept an optional `expected_updated_at` (the ISO timestamp from your last read). Pass it for conflict-safe updates; omit it for last-write-wins, which is fine for most agent flows.
+
 ### Tasks
 - `list_tasks(date?, space_id?)` — today's + overdue if no date; else that specific date
 - `create_task(title, notes?, priority?, task_date?, space_id?, goal_id?)` — priority `A1`-`C9`, defaults to B1
@@ -47,33 +49,44 @@ The MCP server is already registered in the user's OpenClaw config as `cadence`.
 - `get_habit_stats(habit_id, days?)` — default 30 days
 - `create_habit(name, description?, frequency?, target_days?, color?)` — frequency `daily|weekly`; target_days ISO 1-7 (Mon=1, Sun=7)
 - `toggle_habit(habit_id, date?)` — idempotent toggle; defaults to today
+- `update_habit(habit_id, name?, description?, frequency?, target_days?, color?, archived?)` — `archived: true` hides it, `false` restores
+- `delete_habit(habit_id)` — permanent; also deletes its logs. Prefer `update_habit(archived: true)` to keep history
 
 ### Journal
 - `get_journal_entries(date?|from?,to?, limit?)` — specific day or a range
-- `search_journal(query)` — substring search
+- `search_journal(query)` — full-text search over entry content
 - `create_journal_entry(content, entry_date?, mood?)` — mood 1-5; upserts if entry for that date exists
+- `delete_journal_entry(entry_date)` — delete that day's entry
 
 ### Workouts
 - `list_workout_logs(date?|from?,to?)` — most recent 20 if no filter
 - `list_workout_templates()`
 - `log_workout(name, log_date, duration_minutes?, notes?, exercises?)` — `exercises` is a JSON string array; each entry: `{name, type?: "strength"|"timed"|"cardio", sets?, reps?, weight?, duration_seconds?, notes?}`
+- `create_workout_template(name, description?, exercises?)` — save a reusable routine; `exercises` is a JSON string array, each entry `{name, type?, default_sets?, default_reps?, default_weight?, default_duration_seconds?, notes?}`
+- `update_workout_log(log_id, name?, log_date?, duration_minutes?, notes?, exercises?)` — only fields passed change; `exercises` replaces the list (`[]` clears), omit to leave it untouched
+- `delete_workout_log(log_id)` — permanent; also removes its logged exercises
+- `delete_workout_template(template_id)` — permanent; past logs created from it are kept
 
 ### Focus
 - `get_focus_sessions(from?, to?)`
 - `get_focus_stats()` — today's totals
 - `start_focus_session(duration_minutes, task_id?, break_minutes?)` — duration 1-480, break 0-120
 - `complete_focus_session(session_id)`
+- `pause_focus_session(session_id)` — sets status to paused
+- `resume_focus_session(session_id)` — sets a paused session back to active
 
 ### Goals
 - `list_goals(status?)` — status `active|completed|abandoned`
 - `create_goal(title, description?, category?, target_date?)` — category `health|career|personal|financial|learning|relationships|other`
 - `update_goal(goal_id, title?, description?, status?, progress?)` — progress 0-100
 - `log_goal_progress(goal_id, progress)` — just the progress percentage
+- `delete_goal(goal_id)` — permanent; also deletes progress logs. Prefer `update_goal(status: "abandoned")` to keep the record
 
 ### Spaces (projects)
 - `list_spaces()`
 - `create_space(name, description?)`
 - `update_space(space_id, name?, description?, status?)` — status `active|paused|completed`
+- `delete_space(space_id)` — permanent; linked tasks are kept but unlinked
 
 ### Weekly Reviews
 - `get_weekly_review(week_start?)` — latest if omitted

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -74,7 +74,7 @@ Expected — `ok: true`, the transport name, and surface counts:
 {
   "ok": true,
   "transport": "streamable-http",
-  "tools": 34,
+  "tools": 45,
   "prompts": 13,
   "resources": 15,
   "version": "0.1.0"
@@ -93,7 +93,7 @@ curl -s -X POST http://localhost:3000/api/mcp \
   | jq '.result.tools | length'
 ```
 
-Expected output: a number matching `tools` from the health endpoint (e.g. `34`). If you get `null` or an error, double-check `MCP_API_KEY` matches what's in `.env`.
+Expected output: a number matching `tools` from the health endpoint (e.g. `45`). If you get `null` or an error, double-check `MCP_API_KEY` matches what's in `.env`.
 
 ## 5. Tailscale + firewall
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ Expected:
 {
   "ok": true,
   "transport": "streamable-http",
-  "tools": 34,
+  "tools": 45,
   "prompts": 13,
   "resources": 15,
   "version": "..."


### PR DESCRIPTION
## What

Documentation-only follow-up to v2.1.0, which added 11 MCP tools but left the docs describing the old 34-tool surface.

## Changes

- **`docs/mcp-reference.md`** — full entries for the 11 new tools (create_workout_template, update/delete_workout_log, delete_workout_template, update/delete_habit, delete_goal, delete_journal_entry, delete_space, pause/resume_focus_session), a new `Focus status` row, an optimistic-concurrency note, and the corrected error-model note.
- **`docs/openclaw-skill.md`** — the agent-facing tool list gets all 11 new tools plus a short `expected_updated_at` note.
- **Tool count `34` → `45`** across README, docs/index, mcp-reference, local-development, quick-start, troubleshooting (including the `/api/mcp/health` example output).
- Corrected `search_journal` description from "substring" to **full-text** search (it uses `to_tsvector`/`plainto_tsquery`).
- Documented the new focus `paused` status.

No code changes.

https://claude.ai/code/session_0115G2eCmGq3GvdmTSEgw712

---
_Generated by [Claude Code](https://claude.ai/code/session_0115G2eCmGq3GvdmTSEgw712)_