### PR TITLE
chore: sync package.json version to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cadence",
-  "version": "0.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cadence",
-      "version": "0.1.0",
+      "version": "2.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "drizzle-orm": "^0.45.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence",
-  "version": "0.1.0",
+  "version": "2.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Syncs `package.json` to the v2.2.0 release so the MCP health endpoint and server identity report the real version (they read `pkg.version`, which was stuck at 0.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)