### PR TITLE
User-ability review fixes: MCP, dashboard, self-host docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@
 #   uuidgen  (macOS/Linux)
 #   python -c "import uuid; print(uuid.uuid4())"
 # The container auto-seeds a profiles row with this ID on first start.
+# This is PERMANENT — changing it after first boot orphans all your existing
+# data under the old ID and starts you with an empty instance.
 SELF_HOSTED_USER_ID=
 
 # Bearer token that the OpenClaw agent sends on every /api/mcp request.
@@ -11,10 +13,9 @@ SELF_HOSTED_USER_ID=
 #   openssl rand -hex 32
 MCP_API_KEY=
 
-# ---- Recommended ----
-
-# Password for the built-in Postgres container. Pick something random.
-POSTGRES_PASSWORD=changeme
+# Password for the built-in Postgres container. Set a strong random value —
+# do not leave this blank (the stack would fall back to a well-known default).
+POSTGRES_PASSWORD=
 
 # ---- Optional ----
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The container waits for Postgres, runs migrations, seeds the profile row, and st
 
 A `db-backup` sidecar also starts by default and writes nightly `pg_dump` files to `./backups/` next to your compose file, with 14d / 4w / 6m retention. Tune with `BACKUP_SCHEDULE`, `BACKUP_KEEP_DAYS`, etc. in `.env`. **You still need to copy `./backups` offsite** — see [docs/backup-restore.md](docs/backup-restore.md).
 
-For a VPS install, do the same thing on the box and add Tailscale + a firewall rule on port 3000. If you'd rather build the image yourself, see **[docs/DEPLOY.md](docs/DEPLOY.md)**.
+For a VPS install, do the same thing on the box and add Tailscale. The compose file binds the app to `127.0.0.1` (and never publishes Postgres), so nothing is reachable from the public internet — don't rely on a `ufw` rule for port 3000, since Docker's iptables rules sit ahead of ufw and it has no effect. To expose the dashboard on your tailnet, change the bind to your Tailscale IP (see [docs/quick-start.md](docs/quick-start.md)), never `0.0.0.0`. If you'd rather build the image yourself, see **[docs/DEPLOY.md](docs/DEPLOY.md)**.
 
 ## Update
 
@@ -50,7 +50,7 @@ For a VPS install, do the same thing on the box and add Tailscale + a firewall r
 docker compose pull && docker compose up -d
 ```
 
-Pulls the latest image, swaps in a new container, runs any pending migrations automatically. Pin to `:v1` in `docker-compose.yml` for safe auto-upgrades within a major version, or `:latest` for newest.
+Pulls the latest image, swaps in a new container, runs any pending migrations automatically. Pin to the current major (`:2`) in `docker-compose.yml` for safe auto-upgrades within that major version, or `:latest` for newest. (Tags carry no `v` prefix — `:v1`/`:v2` do not exist.)
 
 ## OpenClaw connection
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,11 +1,13 @@
 # cadence — prebuilt-image compose file.
 #
 # Usage:
-#   1. Copy this file to docker-compose.yml
+#   1. Save this file as docker-compose.yml (the quick-start curls it there
+#      for you, so if you followed that you already have it named correctly)
 #   2. Copy .env.example to .env and fill in the required values
 #   3. docker compose up -d
 #
-# Update: docker compose pull && docker compose up -d
+# Update (prebuilt image): docker compose pull && docker compose up -d
+# Building from source instead? See docs/DEPLOY.md.
 
 services:
   postgres:
@@ -30,10 +32,10 @@ services:
       retries: 5
 
   app:
-    # Tracks the latest build from `main`. For a stable pin, use `:1` (floats
-    # within the v1 major, safe for `docker compose pull` auto-upgrades) or
-    # `:1.0.0` for an exact version pin.
-    # Alternatives: docker.io/walrusquant/cadence:latest
+    # Tracks the latest build from `main`. For a stable pin, use the current
+    # major `:2` (floats within v2, safe for `docker compose pull`
+    # auto-upgrades) or `:2.2.0` for an exact version pin. Tags carry no `v`
+    # prefix. Alternatives: docker.io/walrusquant/cadence:latest
     image: ghcr.io/walrusquant/cadence:latest
     container_name: cadence-app
     restart: unless-stopped

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -117,6 +117,8 @@ docker compose up -d --build app
 
 The entrypoint runs any pending migrations on container start.
 
+> This is the **from-source** path — it rebuilds the image locally, so the compose file must use `build:` (not `image:`). If you instead followed the prebuilt-image [quick-start](quick-start.md) (compose uses `image: ghcr.io/...`), update with `docker compose pull && docker compose up -d` — `--build` has nothing to build there.
+
 **View logs:**
 
 ```bash

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -5,6 +5,7 @@ Stand up your instance in about five minutes using the prebuilt container image.
 ## Prerequisites
 
 - A host with **Docker Engine + Docker Compose v2** (any Linux VPS, Raspberry Pi, Apple Silicon Mac, etc. — the image is multi-arch)
+- **`curl`** and **`jq`** for the verification step below (`apt install jq` / `brew install jq` if missing), plus **`openssl`** and **`uuidgen`** (ships with `util-linux`) to generate the secrets
 - **Tailscale** (or another way to reach the host privately — the dashboard has no login; Tailscale *is* the auth layer)
 - An **OpenClaw** install somewhere (your laptop, another VPS — wherever you run the agent)
 
@@ -76,10 +77,11 @@ Expected — `ok: true`, the transport name, and surface counts:
   "transport": "streamable-http",
   "tools": 45,
   "prompts": 13,
-  "resources": 15,
-  "version": "0.1.0"
+  "resources": 15
 }
 ```
+
+(The endpoint also returns a `version` field matching the image you pulled.)
 
 **Authenticated `tools/list`** (uses the bearer token from `.env`):
 
@@ -172,7 +174,7 @@ Mirrored to Docker Hub if you prefer:
 docker.io/walrusquant/cadence:latest
 ```
 
-Available tags: `:latest` (tracks `main`), `:1` / `:1.0` / `:1.0.0` (semver — `:1` floats within the v1 major, `:1.0` within v1.0, `:1.0.0` is an exact pin), and `:sha-<short>` for a pin to a specific commit. Pin to `:1` for safe auto-upgrades within the major version.
+Available tags (no `v` prefix): `:latest` (tracks `main`), semver pins like `:2` / `:2.2` / `:2.2.0` (`:2` floats within the current major, `:2.2` within that minor, `:2.2.0` is an exact pin), and `:sha-<short>` for a pin to a specific commit. Pin to the current major (`:2`) for safe auto-upgrades within it — check [the GHCR tags](https://github.com/WalrusQuant/cadence/pkgs/container/cadence) for the latest.
 
 ## What next
 

--- a/docs/usability-review-2026-06-15.md
+++ b/docs/usability-review-2026-06-15.md
@@ -14,7 +14,7 @@
 
 **Dashboard — highs done** (branch `mcp-usability-fixes`): all 8 high-severity dashboard findings fixed — task-rollover wiring, unscrollable active workout, in-progress workout persistence, editable goal status, space status/deadline, calendar error state, icon-button aria-labels, and a discoverable/touch-reachable command palette (plus the dead Cmd+Shift+S shortcut retired). Remaining: 13 medium + 12 low dashboard findings.
 
-**Self-hoster — pending.** See findings below (image-tag + firewall doc fixes are the highest-value, lowest-risk).
+**Self-hoster — doc fixes done** (branch `mcp-usability-fixes`): image-tag references corrected (`:v1`/`:1` → current major `:2`, no-`v`-prefix note) across README, quick-start, and the compose example; README firewall guidance aligned with the bind-based protection; `POSTGRES_PASSWORD` promoted to Required (blank default); `jq`/`curl`/`openssl`/`uuidgen` added to prerequisites; stale `0.1.0` health-check version dropped; compose-example usage header and update-command divergence clarified; `SELF_HOSTED_USER_ID` permanence documented. The TZ-keying concern was already handled (`.env.example` + compose document `TZ`). Remaining self-hoster item: the empty Briefing/Insight cards placeholder (a dashboard component change, grouped with the dashboard mediums).
 
 ## Executive summary
 

--- a/docs/usability-review-2026-06-15.md
+++ b/docs/usability-review-2026-06-15.md
@@ -12,7 +12,9 @@
 - Stronger `expected_updated_at` guidance to nudge concurrency-safe writes by default — *low*
 - Instantiate a workout template into a log (optional `template_id` on `log_workout` or a new tool) — *low*
 
-**Dashboard / self-hoster — in progress / pending.** See findings below.
+**Dashboard — highs done** (branch `mcp-usability-fixes`): all 8 high-severity dashboard findings fixed — task-rollover wiring, unscrollable active workout, in-progress workout persistence, editable goal status, space status/deadline, calendar error state, icon-button aria-labels, and a discoverable/touch-reachable command palette (plus the dead Cmd+Shift+S shortcut retired). Remaining: 13 medium + 12 low dashboard findings.
+
+**Self-hoster — pending.** See findings below (image-tag + firewall doc fixes are the highest-value, lowest-risk).
 
 ## Executive summary
 

--- a/docs/usability-review-2026-06-15.md
+++ b/docs/usability-review-2026-06-15.md
@@ -12,9 +12,18 @@
 - Stronger `expected_updated_at` guidance to nudge concurrency-safe writes by default — *low*
 - Instantiate a workout template into a log (optional `template_id` on `log_workout` or a new tool) — *low*
 
-**Dashboard — highs done** (branch `mcp-usability-fixes`): all 8 high-severity dashboard findings fixed — task-rollover wiring, unscrollable active workout, in-progress workout persistence, editable goal status, space status/deadline, calendar error state, icon-button aria-labels, and a discoverable/touch-reachable command palette (plus the dead Cmd+Shift+S shortcut retired). Remaining: 13 medium + 12 low dashboard findings.
+**Dashboard — highs + mediums + most lows done** (branch `mcp-usability-fixes`):
+- *Highs (8):* task-rollover wiring, unscrollable active workout, in-progress workout persistence, editable goal status, space status/deadline, calendar error state, icon-button aria-labels, discoverable/touch-reachable command palette (dead Cmd+Shift+S retired).
+- *Mediums:* honest empty/error states (briefing placeholder, weekly-review error vs empty), dashboard refresh after Daily Start, confirm-before-delete (tasks/goals/habits/workout logs), settings tab aria + visible focus rings, future-date clamping (habits/journal), recurrence badge, focus-completion system notifications, goal↔task linking (discoverable + two-directional), calendar day-cell aria-labels.
+- *Lows:* `@tailwindcss/typography` so briefings render styled markdown, ErrorBoundary generic message + reload/dashboard escapes, toast lifted above mobile nav, goal target-date formatting, always-show habit completion badge, workout-finish hint, priority sub-rank caption, cross-priority drag feedback, forgiving wipe confirmation, journal mood-needs-text hint.
 
-**Self-hoster — doc fixes done** (branch `mcp-usability-fixes`): image-tag references corrected (`:v1`/`:1` → current major `:2`, no-`v`-prefix note) across README, quick-start, and the compose example; README firewall guidance aligned with the bind-based protection; `POSTGRES_PASSWORD` promoted to Required (blank default); `jq`/`curl`/`openssl`/`uuidgen` added to prerequisites; stale `0.1.0` health-check version dropped; compose-example usage header and update-command divergence clarified; `SELF_HOSTED_USER_ID` permanence documented. The TZ-keying concern was already handled (`.env.example` + compose document `TZ`). Remaining self-hoster item: the empty Briefing/Insight cards placeholder (a dashboard component change, grouped with the dashboard mediums).
+**Dashboard — deferred (judgment calls):**
+- Re-enable pinch-to-zoom (`layout.tsx`) — needs a sweep to bump all inputs to ≥16px first, or iOS will auto-zoom on focus. Accessibility-vs-UX tradeoff worth a deliberate decision. *low*
+- Mobile theme toggle / reachable full sidebar — theme is already reachable via Settings → Preferences; low value. *low*
+- Full mood-only journal entries — `content` is `NOT NULL` and the route requires it, so this needs a schema migration + route change (a text hint was added in the meantime). *low*
+- Blanket "every async view routes failures to ErrorBoundary" — the highest-traffic views (calendar, weekly review, briefing) now have explicit error/empty states; remaining views can adopt the same pattern incrementally. *medium*
+
+**Self-hoster — doc fixes done** (branch `mcp-usability-fixes`): image-tag references corrected (`:v1`/`:1` → current major `:2`, no-`v`-prefix note) across README, quick-start, and the compose example; README firewall guidance aligned with the bind-based protection; `POSTGRES_PASSWORD` promoted to Required (blank default); `jq`/`curl`/`openssl`/`uuidgen` added to prerequisites; stale `0.1.0` health-check version dropped; compose-example usage header and update-command divergence clarified; `SELF_HOSTED_USER_ID` permanence documented. The TZ-keying concern was already handled (`.env.example` + compose document `TZ`). The empty Briefing/Insight cards placeholder is covered by the briefing placeholder above.
 
 ## Executive summary
 

--- a/docs/usability-review-2026-06-15.md
+++ b/docs/usability-review-2026-06-15.md
@@ -2,6 +2,18 @@
 
 > Multi-agent review focused on user ability across three audiences: the dashboard human user, the self-hoster/installer, and the OpenClaw (model-agnostic LLM) MCP consumer. 60 findings verified against the actual code/docs.
 
+## Implementation status
+
+**MCP — done** (branch `mcp-usability-fixes`): 13 of 17 MCP findings fixed across two commits — the save-loop blocker, all three highs, and the safe validation/discoverability items.
+
+**MCP — deferred for later** (4 items; these change the tool contract OpenClaw already calls or add a feature, so they need a heads-up to whoever runs OpenClaw before shipping):
+- `exercises` payload as a real array instead of a JSON-encoded string (`tools/workouts.ts`) — *medium*
+- `save_insights` shape tightening to a minimal insight-object schema (`tools/insights.ts`) — *low*
+- Stronger `expected_updated_at` guidance to nudge concurrency-safe writes by default — *low*
+- Instantiate a workout template into a log (optional `template_id` on `log_workout` or a new tool) — *low*
+
+**Dashboard / self-hoster — in progress / pending.** See findings below.
+
 ## Executive summary
 
 Cadence's three audiences experience sharply different levels of polish. The **MCP/OpenClaw consumer** has the most damaging defect: no generative prompt instructs the agent to save its output, so the entire read→generate→save loop silently produces nothing and the dashboard's agent-fed widgets stay empty forever — a blocker that masks several other prompt/data-keying correctness risks. The **dashboard user** hits multiple built-but-unwired core features (task rollover, goal close-out, space lifecycle fields) plus two hard blockers on mobile (unscrollable active workout, unsaved in-progress workout loss). The **self-hoster** is mostly served well but is steered by docs toward a non-existent/stale image tag and a false-security firewall rule. The three highest-leverage fixes: (1) append explicit save-tool instructions to every generative prompt and echo machine-targeted date keys; (2) wire up the orphaned dashboard features (rollover banner, goal/space status editors) that already have full backend support; (3) correct the image-tag and firewall guidance in README/quick-start so installs don't fail or feel insecure.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cadence",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cadence",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "drizzle-orm": "^0.45.2",
@@ -3139,6 +3139,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       "devDependencies": {
         "@electric-sql/pglite": "^0.5.1",
         "@tailwindcss/postcss": "^4",
+        "@tailwindcss/typography": "^0.5.20",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -3187,6 +3188,19 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.20",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.20.tgz",
+      "integrity": "sha512-hwbzQuNUfcPvbegQFatVPl/MY/tcM9KLl963hQ5laJKPh81TEZ1+dNG9PirGvcaDBkp+BCshExAyKVPW91dozw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >=4.0.0 || insiders"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -5014,6 +5028,19 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/cssstyle": {
       "version": "6.2.0",
@@ -10234,6 +10261,20 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postgres": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.9.tgz",
@@ -12091,6 +12132,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cadence",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@electric-sql/pglite": "^0.5.1",
     "@tailwindcss/postcss": "^4",
+    "@tailwindcss/typography": "^0.5.20",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 html {
   margin: 0;

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -56,16 +56,42 @@ export class ErrorBoundary extends Component<
               Something went wrong
             </h2>
             <p className="mb-6" style={{ color: "var(--text-secondary)" }}>
-              {this.state.error?.message || "An unexpected error occurred"}
+              An unexpected error occurred. Try again, or reload the page.
             </p>
-            <button
-              onClick={this.handleRetry}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg hover:opacity-90 transition-opacity font-medium"
-              style={{ background: "var(--accent-primary)", color: "var(--bg-base)" }}
-            >
-              <RefreshCw className="w-4 h-4" />
-              Try Again
-            </button>
+            <div className="flex flex-wrap items-center justify-center gap-2">
+              <button
+                onClick={this.handleRetry}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg hover:opacity-90 transition-opacity font-medium"
+                style={{ background: "var(--accent-primary)", color: "var(--bg-base)" }}
+              >
+                <RefreshCw className="w-4 h-4" />
+                Try Again
+              </button>
+              <button
+                onClick={() => window.location.reload()}
+                className="px-4 py-2 rounded-lg transition-colors font-medium"
+                style={{ color: "var(--text-secondary)", border: "1px solid var(--border-default)" }}
+              >
+                Reload page
+              </button>
+              <a
+                href="/dashboard"
+                className="px-4 py-2 rounded-lg transition-colors font-medium"
+                style={{ color: "var(--text-secondary)", border: "1px solid var(--border-default)" }}
+              >
+                Go to dashboard
+              </a>
+            </div>
+            {this.state.error?.message && (
+              <details className="mt-6 text-left max-w-full">
+                <summary className="text-xs cursor-pointer" style={{ color: "var(--text-muted)" }}>
+                  Technical details
+                </summary>
+                <pre className="mt-2 text-xs whitespace-pre-wrap break-words" style={{ color: "var(--text-muted)" }}>
+                  {this.state.error.message}
+                </pre>
+              </details>
+            )}
           </div>
         </div>
       );

--- a/src/components/calendar/CalendarDayCell.tsx
+++ b/src/components/calendar/CalendarDayCell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatDate } from "@/lib/dates";
 import type { DaySummary } from "./types";
 
 interface CalendarDayCellProps {
@@ -78,9 +79,23 @@ export function CalendarDayCell({
   const isOutsideMonth = dateMonth !== currentMonth;
   const badges = summary ? getBadges(summary) : [];
 
+  // Screen readers otherwise hear just "15, button" with no month/year or
+  // activity context, and no way to tell the selected day apart.
+  const activity: string[] = [];
+  if (summary) {
+    if (summary.tasks.total > 0) activity.push(`${summary.tasks.done} of ${summary.tasks.total} tasks done`);
+    if (summary.habits.total > 0) activity.push(`${summary.habits.completed} of ${summary.habits.total} habits`);
+    if (summary.journal.hasEntry) activity.push("journal entry");
+    if (summary.workouts.count > 0) activity.push(`${summary.workouts.count} workout${summary.workouts.count > 1 ? "s" : ""}`);
+    if (summary.focus.sessions > 0) activity.push(`${summary.focus.minutes} min focus`);
+  }
+  const ariaLabel = `${formatDate(date, "long")}${isToday ? " (today)" : ""}, ${activity.length ? activity.join(", ") : "no activity"}`;
+
   return (
     <button
       onClick={() => onClick(date)}
+      aria-label={ariaLabel}
+      aria-pressed={isSelected}
       className="relative flex flex-col items-start p-1 md:p-2 transition-colors overflow-hidden w-full h-full"
       style={{
         borderRight: "1px solid var(--border-default)",

--- a/src/components/calendar/CalendarView.tsx
+++ b/src/components/calendar/CalendarView.tsx
@@ -13,6 +13,7 @@ export function CalendarView() {
   const [gridDates, setGridDates] = useState<string[]>([]);
   const [summaries, setSummaries] = useState<Record<string, DaySummary>>({});
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [dayDetail, setDayDetail] = useState<DayDetail | null>(null);
   const [isDetailLoading, setIsDetailLoading] = useState(false);
@@ -25,28 +26,33 @@ export function CalendarView() {
     return () => window.removeEventListener("resize", check);
   }, []);
 
+  const fetchMonth = useCallback(async (signal?: AbortSignal) => {
+    setIsLoading(true);
+    setError(false);
+    try {
+      const res = await fetch(`/api/calendar?month=${currentMonth}`, signal ? { signal } : undefined);
+      if (res.ok) {
+        const data = await res.json();
+        setSummaries(data.summaries);
+        setGridDates(data.gridDates);
+      } else {
+        setError(true);
+      }
+    } catch (err) {
+      if (signal?.aborted) return;
+      console.error("Failed to fetch calendar data:", err);
+      setError(true);
+    } finally {
+      if (!signal?.aborted) setIsLoading(false);
+    }
+  }, [currentMonth]);
+
   useEffect(() => {
     // Abort on month change/unmount so a slow response can't render a stale month.
     const controller = new AbortController();
-    const fetchMonth = async () => {
-      setIsLoading(true);
-      try {
-        const res = await fetch(`/api/calendar?month=${currentMonth}`, { signal: controller.signal });
-        if (res.ok) {
-          const data = await res.json();
-          setSummaries(data.summaries);
-          setGridDates(data.gridDates);
-        }
-      } catch (err) {
-        if (controller.signal.aborted) return;
-        console.error("Failed to fetch calendar data:", err);
-      } finally {
-        if (!controller.signal.aborted) setIsLoading(false);
-      }
-    };
-    fetchMonth();
+    fetchMonth(controller.signal);
     return () => controller.abort();
-  }, [currentMonth]);
+  }, [fetchMonth]);
 
   // Click-driven (not effect-driven), so guard with a request counter: only
   // the latest selected day's response may write state.
@@ -108,6 +114,7 @@ export function CalendarView() {
         <div className="flex items-center gap-1">
           <button
             onClick={goToPrev}
+            aria-label="Previous month"
             className="p-2 rounded-lg transition-colors hover:opacity-80"
             style={{ color: "var(--text-secondary)" }}
           >
@@ -121,6 +128,7 @@ export function CalendarView() {
           </h2>
           <button
             onClick={goToNext}
+            aria-label="Next month"
             className="p-2 rounded-lg transition-colors hover:opacity-80"
             style={{ color: "var(--text-secondary)" }}
           >
@@ -146,6 +154,19 @@ export function CalendarView() {
       {isLoading ? (
         <div className="flex-1 flex items-center justify-center">
           <Loader2 className="w-6 h-6 animate-spin" style={{ color: "var(--text-muted)" }} />
+        </div>
+      ) : error ? (
+        <div className="flex-1 flex flex-col items-center justify-center gap-3">
+          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+            Couldn&apos;t load the calendar.
+          </p>
+          <button
+            onClick={() => fetchMonth()}
+            className="text-xs px-3 py-1.5 rounded-lg font-medium transition-colors"
+            style={{ color: "var(--accent-primary)", background: "var(--bg-elevated)" }}
+          >
+            Retry
+          </button>
         </div>
       ) : gridDates.length > 0 ? (
         <CalendarGrid

--- a/src/components/calendar/DayDetailPanel.tsx
+++ b/src/components/calendar/DayDetailPanel.tsx
@@ -41,6 +41,7 @@ export function DayDetailPanel({ detail, isLoading, onClose, isMobile }: DayDeta
         </h3>
         <button
           onClick={onClose}
+          aria-label="Close"
           className="p-1 rounded-lg transition-colors"
           style={{ color: "var(--text-muted)" }}
         >

--- a/src/components/dashboard/DailyBriefing.tsx
+++ b/src/components/dashboard/DailyBriefing.tsx
@@ -44,7 +44,24 @@ export function DailyBriefing() {
     );
   }
 
-  if (!content) return null;
+  if (!content) {
+    return (
+      <div
+        className="rounded-xl p-4 mb-4"
+        style={{ background: "var(--bg-surface)", border: "1px solid var(--border-default)" }}
+      >
+        <div className="flex items-center gap-2 mb-1">
+          <Sparkles className="w-4 h-4" style={{ color: "var(--accent-primary)" }} />
+          <span className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
+            Daily Briefing
+          </span>
+        </div>
+        <p className="text-xs" style={{ color: "var(--text-muted)" }}>
+          No briefing yet — your OpenClaw agent posts the morning briefing here once it runs.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/src/components/dashboard/DailyStartCard.tsx
+++ b/src/components/dashboard/DailyStartCard.tsx
@@ -11,17 +11,22 @@ interface DailyStartCardProps {
   tasks: { total: number; done: number; topPriorities: Task[] };
   habits: { total: number; completedToday: number; streak: number };
   focus: { todayMinutes: number; todaySessions: number };
+  onTaskComplete?: () => void;
 }
 
-export function DailyStartCard({ tasks, habits, focus }: DailyStartCardProps) {
+export function DailyStartCard({ tasks, habits, focus, onTaskComplete }: DailyStartCardProps) {
   const timer = useFocusTimerContext();
   const { addToast } = useToast();
   const [dismissed, setDismissed] = useState(
     () => typeof window !== "undefined" && sessionStorage.getItem("daily-start-dismissed") === "true"
   );
-  const [taskDone, setTaskDone] = useState(false);
+  const [completedId, setCompletedId] = useState<string | null>(null);
 
   const topTask = tasks.topPriorities.find((t) => !t.done) || null;
+  // Derived, not effect-synced: strike through only while the just-completed
+  // task is still the top task. Once a reload refreshes props it drops off the
+  // undone list and the card advances to the next task on its own.
+  const showDone = !!topTask && topTask.id === completedId;
 
   const handleDismiss = () => {
     setDismissed(true);
@@ -31,19 +36,23 @@ export function DailyStartCard({ tasks, habits, focus }: DailyStartCardProps) {
   const handleCompleteTask = async () => {
     if (!topTask) return;
     // Optimistic update
-    setTaskDone(true);
+    setCompletedId(topTask.id);
     try {
       const response = await fetch(`/api/tasks/${topTask.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ done: true }),
       });
-      if (!response.ok) {
-        setTaskDone(false);
+      if (response.ok) {
+        addToast("Task completed");
+        // Refresh the dashboard widgets so counts/progress reflect the change.
+        onTaskComplete?.();
+      } else {
+        setCompletedId(null);
         addToast("Failed to complete task");
       }
     } catch {
-      setTaskDone(false);
+      setCompletedId(null);
       addToast("Failed to complete task");
     }
   };
@@ -93,9 +102,9 @@ export function DailyStartCard({ tasks, habits, focus }: DailyStartCardProps) {
         <div className="flex items-center gap-3">
           <CheckCircle2
             className="w-4 h-4 shrink-0"
-            style={{ color: taskDone ? "var(--accent-positive)" : "var(--text-muted)" }}
+            style={{ color: showDone ? "var(--accent-positive)" : "var(--text-muted)" }}
           />
-          {topTask && !taskDone ? (
+          {topTask && !showDone ? (
             <button
               onClick={handleCompleteTask}
               className="flex-1 text-left text-sm transition-colors"
@@ -109,7 +118,7 @@ export function DailyStartCard({ tasks, habits, focus }: DailyStartCardProps) {
               </span>
               {topTask.title}
             </button>
-          ) : taskDone ? (
+          ) : showDone ? (
             <span className="text-sm line-through" style={{ color: "var(--text-muted)" }}>
               {topTask?.title || "Task completed"}
             </span>

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { LayoutDashboard } from "lucide-react";
 import { DashboardSkeleton } from "@/components/shared/Skeleton";
 import { TaskWidget } from "./TaskWidget";
@@ -28,21 +28,22 @@ export function Dashboard() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const response = await fetch("/api/dashboard");
-        if (response.ok) {
-          setData(await response.json());
-        }
-      } catch (error) {
-        console.error("Failed to load dashboard:", error);
-      } finally {
-        setIsLoading(false);
+  const reload = useCallback(async () => {
+    try {
+      const response = await fetch("/api/dashboard");
+      if (response.ok) {
+        setData(await response.json());
       }
-    };
-    load();
+    } catch (error) {
+      console.error("Failed to load dashboard:", error);
+    } finally {
+      setIsLoading(false);
+    }
   }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
 
   if (isLoading) {
     return <DashboardSkeleton />;
@@ -68,7 +69,7 @@ export function Dashboard() {
       </div>
 
       <DailyBriefing />
-      <DailyStartCard tasks={data.tasks} habits={data.habits} focus={data.focus} />
+      <DailyStartCard tasks={data.tasks} habits={data.habits} focus={data.focus} onTaskComplete={reload} />
       <InsightCards />
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/components/goals/GoalDetail.tsx
+++ b/src/components/goals/GoalDetail.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { ArrowLeft, CheckSquare, Target, CalendarDays } from "lucide-react";
 import { Goal, Task, Habit, GoalProgressLog } from "@/types/database";
 import { SparklineChart } from "@/components/shared/SparklineChart";
+import { formatDate } from "@/lib/dates";
 
 interface GoalWithLinked extends Goal {
   tasks: Task[];
@@ -116,7 +117,7 @@ export function GoalDetail({ goalId, onBack }: GoalDetailProps) {
           {goal.target_date && (
             <span className="flex items-center gap-1">
               <CalendarDays className="w-3 h-3" />
-              Target: {goal.target_date}
+              Target: {formatDate(goal.target_date)}
             </span>
           )}
           <span className="capitalize">{goal.progress_mode} progress</span>

--- a/src/components/goals/GoalDetail.tsx
+++ b/src/components/goals/GoalDetail.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { ArrowLeft, CheckSquare, Target, CalendarDays } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { ArrowLeft, CheckSquare, Target, CalendarDays, Plus } from "lucide-react";
 import { Goal, Task, Habit, GoalProgressLog } from "@/types/database";
 import { SparklineChart } from "@/components/shared/SparklineChart";
-import { formatDate } from "@/lib/dates";
+import { formatDate, getToday } from "@/lib/dates";
+import { TaskFormModal } from "@/components/tasks/TaskFormModal";
 
 interface GoalWithLinked extends Goal {
   tasks: Task[];
@@ -30,24 +31,26 @@ export function GoalDetail({ goalId, onBack }: GoalDetailProps) {
   const [goal, setGoal] = useState<GoalWithLinked | null>(null);
   const [progressLogs, setProgressLogs] = useState<GoalProgressLog[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [showTaskForm, setShowTaskForm] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const [goalRes, progressRes] = await Promise.all([
+        fetch(`/api/goals/${goalId}`),
+        fetch(`/api/goals/${goalId}/progress`),
+      ]);
+      if (goalRes.ok) setGoal(await goalRes.json());
+      if (progressRes.ok) setProgressLogs(await progressRes.json());
+    } catch (err) {
+      console.error("Failed to load goal detail:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [goalId]);
 
   useEffect(() => {
-    const load = async () => {
-      try {
-        const [goalRes, progressRes] = await Promise.all([
-          fetch(`/api/goals/${goalId}`),
-          fetch(`/api/goals/${goalId}/progress`),
-        ]);
-        if (goalRes.ok) setGoal(await goalRes.json());
-        if (progressRes.ok) setProgressLogs(await progressRes.json());
-      } catch (err) {
-        console.error("Failed to load goal detail:", err);
-      } finally {
-        setIsLoading(false);
-      }
-    };
     load();
-  }, [goalId]);
+  }, [load]);
 
   if (isLoading) {
     return (
@@ -139,6 +142,13 @@ export function GoalDetail({ goalId, onBack }: GoalDetailProps) {
           <h3 className="text-sm font-medium" style={{ color: "var(--text-primary)" }}>
             Linked Tasks ({doneTasks}/{goal.tasks.length})
           </h3>
+          <button
+            onClick={() => setShowTaskForm(true)}
+            className="ml-auto flex items-center gap-1 text-xs px-2 py-1 rounded transition-colors"
+            style={{ color: "var(--accent-primary)" }}
+          >
+            <Plus className="w-3 h-3" /> Add task
+          </button>
         </div>
         {goal.tasks.length === 0 ? (
           <p className="text-xs" style={{ color: "var(--text-muted)" }}>No tasks linked to this goal</p>
@@ -178,6 +188,18 @@ export function GoalDetail({ goalId, onBack }: GoalDetailProps) {
           </div>
         )}
       </div>
+
+      {showTaskForm && (
+        <TaskFormModal
+          defaultGoalId={goal.id}
+          defaultDate={getToday()}
+          onClose={() => setShowTaskForm(false)}
+          onSave={() => {
+            setShowTaskForm(false);
+            load();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/goals/GoalFormModal.tsx
+++ b/src/components/goals/GoalFormModal.tsx
@@ -26,6 +26,7 @@ export function GoalFormModal({ goal, onClose, onSave }: GoalFormModalProps) {
   const [description, setDescription] = useState(goal?.description || "");
   const [category, setCategory] = useState<string>(goal?.category || "personal");
   const [targetDate, setTargetDate] = useState(goal?.target_date || "");
+  const [status, setStatus] = useState<string>(goal?.status || "active");
   const [progressMode, setProgressMode] = useState(goal?.progress_mode || "auto");
   const [progress, setProgress] = useState(goal?.progress || 0);
   const [isSaving, setIsSaving] = useState(false);
@@ -50,6 +51,12 @@ export function GoalFormModal({ goal, onClose, onSave }: GoalFormModalProps) {
 
       if (progressMode === "manual") {
         body.progress = progress;
+      }
+
+      // Status transitions (complete/abandon/reactivate) only apply to an
+      // existing goal; a new goal always starts active.
+      if (goal) {
+        body.status = status;
       }
 
       if (goal?.updated_at) {
@@ -147,6 +154,24 @@ export function GoalFormModal({ goal, onClose, onSave }: GoalFormModalProps) {
             />
           </div>
         </div>
+
+        {goal && (
+          <div>
+            <label className="block text-sm font-medium mb-1" style={{ color: "var(--text-secondary)" }}>
+              Status
+            </label>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
+              style={{ background: "var(--bg-base)", color: "var(--text-primary)", border: "1px solid var(--border-default)" }}
+            >
+              <option value="active">Active</option>
+              <option value="completed">Completed</option>
+              <option value="abandoned">Abandoned</option>
+            </select>
+          </div>
+        )}
 
         <div>
           <label className="block text-sm font-medium mb-1" style={{ color: "var(--text-secondary)" }}>

--- a/src/components/goals/GoalList.tsx
+++ b/src/components/goals/GoalList.tsx
@@ -48,6 +48,7 @@ export function GoalList() {
   };
 
   const handleDelete = async (goal: Goal) => {
+    if (!confirm(`Delete "${goal.title}"? This also removes its progress history and cannot be undone. To keep the record, set it to Abandoned instead.`)) return;
     try {
       const res = await fetch(`/api/goals/${goal.id}`, { method: "DELETE" });
       if (res.ok) setGoals((prev) => prev.filter((g) => g.id !== goal.id));

--- a/src/components/goals/GoalPicker.tsx
+++ b/src/components/goals/GoalPicker.tsx
@@ -23,7 +23,23 @@ export function GoalPicker({ value, onChange }: GoalPickerProps) {
     load();
   }, []);
 
-  if (goals.length === 0) return null;
+  if (goals.length === 0) {
+    return (
+      <div>
+        <label className="block text-sm font-medium mb-1" style={{ color: "var(--text-secondary)" }}>
+          Goal
+        </label>
+        <select
+          disabled
+          value=""
+          className="w-full rounded-lg px-3 py-2 text-sm opacity-60 cursor-not-allowed"
+          style={{ background: "var(--bg-base)", color: "var(--text-muted)", border: "1px solid var(--border-default)" }}
+        >
+          <option>No goals yet — create one to link tasks</option>
+        </select>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/src/components/habits/HabitRow.tsx
+++ b/src/components/habits/HabitRow.tsx
@@ -76,11 +76,13 @@ export function HabitRow({ habit, weekDates, loggedDates, streak, completionRate
 
       {/* Row 3 (mobile) / inline (desktop): stats + desktop actions */}
       <div className="flex items-center gap-2 flex-1 min-w-0 justify-end">
-        {completionRate > 0 && (
-          <span className="text-xs font-medium px-1.5 py-0.5 rounded-full" style={{ background: "var(--bg-elevated)", color: "var(--text-muted)" }}>
-            {Math.round(completionRate * 100)}%
-          </span>
-        )}
+        <span
+          className="text-xs font-medium px-1.5 py-0.5 rounded-full"
+          style={{ background: "var(--bg-elevated)", color: "var(--text-muted)" }}
+          title="30-day completion rate"
+        >
+          {Math.round(completionRate * 100)}%
+        </span>
         {streak > 0 && (
           <span className="text-xs font-medium px-2 py-0.5 rounded-full" style={{ background: "var(--bg-elevated)", color: "var(--accent-primary)" }}>
             {streak}d streak

--- a/src/components/habits/HabitTracker.tsx
+++ b/src/components/habits/HabitTracker.tsx
@@ -185,6 +185,7 @@ export function HabitTracker() {
   };
 
   const handleDelete = async (habit: Habit) => {
+    if (!confirm(`Delete "${habit.name}"? This removes all of its logged history and streaks and cannot be undone. To keep the history, archive it instead.`)) return;
     // Optimistic removal
     const prevHabitsWithStats = habitsWithStats;
     setHabitsWithStats((prev) => prev.filter((hs) => hs.habit.id !== habit.id));

--- a/src/components/habits/HabitTracker.tsx
+++ b/src/components/habits/HabitTracker.tsx
@@ -211,7 +211,7 @@ export function HabitTracker() {
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-xl font-bold" style={{ color: "var(--text-primary)" }}>Habits</h1>
         <div className="flex items-center gap-3">
-          <DateNavigation date={date} onDateChange={setDate} mode="week" />
+          <DateNavigation date={date} onDateChange={setDate} mode="week" maxDate={getToday()} />
           <button
             onClick={() => { setEditingHabit(null); setShowForm(true); }}
             className="p-2 rounded-lg transition-opacity hover:opacity-90"

--- a/src/components/journal/JournalEditor.tsx
+++ b/src/components/journal/JournalEditor.tsx
@@ -122,6 +122,12 @@ export function JournalEditor({ entryId, initialContent = "", initialMood = null
         })}
       </div>
 
+      {mood !== null && !content.trim() && (
+        <p className="text-xs" style={{ color: "var(--text-muted)" }}>
+          Write something below to save today&apos;s mood.
+        </p>
+      )}
+
       <textarea
         value={content}
         onChange={(e) => setContent(e.target.value)}

--- a/src/components/journal/JournalView.tsx
+++ b/src/components/journal/JournalView.tsx
@@ -107,7 +107,7 @@ export function JournalView() {
     <div className="max-w-2xl mx-auto p-4 md:p-6">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-xl font-bold" style={{ color: "var(--text-primary)" }}>Journal</h1>
-        <DateNavigation date={date} onDateChange={setDate} />
+        <DateNavigation date={date} onDateChange={setDate} maxDate={getToday()} />
       </div>
 
       {/* Key on date only: remounting when the first save assigns an id would

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -17,7 +17,9 @@ import {
   FileText,
   Settings,
   Crosshair,
+  Search,
 } from "lucide-react";
+import { useCommandPalette } from "@/lib/command-palette-context";
 
 const TABS = [
   { href: "/dashboard", icon: LayoutDashboard, label: "Dashboard", match: "/dashboard" },
@@ -38,6 +40,7 @@ const MORE_ITEMS = [
 
 export function BottomNav() {
   const pathname = usePathname();
+  const { toggle: toggleCommandPalette } = useCommandPalette();
   const [showMore, setShowMore] = useState(false);
   const [keyboardOpen, setKeyboardOpen] = useState(false);
 
@@ -82,6 +85,14 @@ export function BottomNav() {
               </button>
             </div>
             <div className="grid grid-cols-3 gap-2">
+              <button
+                onClick={() => { setShowMore(false); toggleCommandPalette(); }}
+                className="flex flex-col items-center gap-1 py-3 rounded-lg transition-colors"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                <Search className="w-5 h-5" />
+                <span className="text-xs">Search</span>
+              </button>
               {MORE_ITEMS.map((item) => {
                 const isActive = pathname.startsWith(item.href);
                 return (

--- a/src/components/layout/ProtectedLayoutClient.tsx
+++ b/src/components/layout/ProtectedLayoutClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useEffect } from "react";
 import dynamic from "next/dynamic";
 
 import { ErrorBoundary } from "@/components/ErrorBoundary";
@@ -30,14 +30,6 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
   const { toggle: toggleCommandPalette } = useCommandPalette();
 
-  const focusSidebarSearch = useCallback(() => {
-    setSidebarOpen(true);
-    setCollapsed(false);
-    setTimeout(() => {
-      window.dispatchEvent(new Event("focus-sidebar-search"));
-    }, 100);
-  }, []);
-
   // Fix iOS PWA bottom gap: innerHeight excludes ~62px on initial load
   // in standalone mode, but screen.height is always correct (874 vs 812).
   // Use screen.height on mount, innerHeight on resize (corrected by then).
@@ -57,7 +49,6 @@ function LayoutInner({ children }: { children: React.ReactNode }) {
 
   useKeyboardShortcuts([
     { key: "k", metaKey: true, allowInInput: true, handler: toggleCommandPalette },
-    { key: "s", metaKey: true, shiftKey: true, handler: focusSidebarSearch },
     {
       key: "Escape",
       handler: () => {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -21,9 +21,11 @@ import {
   FileText,
   CalendarDays,
   Crosshair,
+  Search,
 } from "lucide-react";
 import { FocusTimerBadge } from "@/components/focus/FocusTimerBadge";
 import { useTheme } from "@/lib/theme";
+import { useCommandPalette } from "@/lib/command-palette-context";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -37,6 +39,12 @@ export function Sidebar({ isOpen, onClose, collapsed, onToggleCollapse }: Sideba
 
   const pathname = usePathname();
   const { theme, setTheme } = useTheme();
+  const { toggle: toggleCommandPalette } = useCommandPalette();
+
+  const handleSearchClick = () => {
+    toggleCommandPalette();
+    handleNavClick();
+  };
 
   useEffect(() => {
     let cancelled = false;
@@ -148,6 +156,16 @@ export function Sidebar({ isOpen, onClose, collapsed, onToggleCollapse }: Sideba
 
           {collapsed ? (
             <div className="flex flex-col items-center gap-0.5">
+              <button
+                onClick={handleSearchClick}
+                className="p-2 rounded-lg transition-colors"
+                style={{ color: "var(--text-secondary)" }}
+                title="Search (⌘K)"
+                aria-label="Search"
+              >
+                <Search className="w-4 h-4" />
+              </button>
+
               {primaryLinks.map((link) => (
                 <Link
                   key={link.href}
@@ -212,6 +230,21 @@ export function Sidebar({ isOpen, onClose, collapsed, onToggleCollapse }: Sideba
             </div>
           ) : (
             <div className="space-y-0.5">
+              <button
+                onClick={handleSearchClick}
+                className="w-full flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-colors"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                <Search className="w-4 h-4" />
+                <span className="flex-1 text-left">Search</span>
+                <kbd
+                  className="text-[10px] px-1.5 py-0.5 rounded"
+                  style={{ background: "var(--bg-elevated)", color: "var(--text-muted)" }}
+                >
+                  ⌘K
+                </kbd>
+              </button>
+
               {primaryLinks.map((link) => (
                 <Link
                   key={link.href}

--- a/src/components/review/WeeklyReview.tsx
+++ b/src/components/review/WeeklyReview.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Loader2, FileText } from "lucide-react";
+import { useState, useEffect, useCallback } from "react";
+import { Loader2, FileText, AlertCircle } from "lucide-react";
 import { DateNavigation } from "@/components/shared/DateNavigation";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { startOfWeek, getToday } from "@/lib/dates";
@@ -13,6 +13,7 @@ export function WeeklyReview() {
   const [weekStart, setWeekStart] = useState(startOfWeek(getToday()));
   const [content, setContent] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [dashboardStats, setDashboardStats] = useState<{
     tasks?: { total: number; done: number };
     habits?: { total: number; completedToday: number; streak: number };
@@ -20,31 +21,34 @@ export function WeeklyReview() {
     workouts?: { weekCount: number };
   } | null>(null);
 
+  const loadReview = useCallback(async (signal?: AbortSignal) => {
+    setIsLoading(true);
+    setError(false);
+    try {
+      const response = await fetch(`/api/weekly-review?week=${weekStart}`, signal ? { signal } : undefined);
+      if (response.ok) {
+        const data = await response.json();
+        setContent(data && data.content ? data.content : "");
+      } else {
+        // A failed fetch is not the same as "no review yet" — don't blame the agent.
+        setError(true);
+        setContent("");
+      }
+    } catch {
+      if (signal?.aborted) return;
+      setError(true);
+      setContent("");
+    } finally {
+      if (!signal?.aborted) setIsLoading(false);
+    }
+  }, [weekStart]);
+
   useEffect(() => {
     // Abort on week change/unmount so a slow response can't render a stale week.
     const controller = new AbortController();
-    const loadReview = async () => {
-      setIsLoading(true);
-      try {
-        const response = await fetch(`/api/weekly-review?week=${weekStart}`, {
-          signal: controller.signal,
-        });
-        if (response.ok) {
-          const data = await response.json();
-          setContent(data && data.content ? data.content : "");
-        } else {
-          setContent("");
-        }
-      } catch {
-        if (controller.signal.aborted) return;
-        setContent("");
-      } finally {
-        if (!controller.signal.aborted) setIsLoading(false);
-      }
-    };
-    loadReview();
+    loadReview(controller.signal);
     return () => controller.abort();
-  }, [weekStart]);
+  }, [loadReview]);
 
   useEffect(() => {
     fetch("/api/dashboard")
@@ -68,6 +72,20 @@ export function WeeklyReview() {
       {isLoading ? (
         <div className="flex justify-center py-12">
           <Loader2 className="w-6 h-6 animate-spin" style={{ color: "var(--text-muted)" }} />
+        </div>
+      ) : error ? (
+        <div className="flex flex-col items-center gap-3 py-12">
+          <AlertCircle className="w-6 h-6" style={{ color: "var(--text-muted)" }} />
+          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+            Couldn&apos;t load this week&apos;s review.
+          </p>
+          <button
+            onClick={() => loadReview()}
+            className="text-xs px-3 py-1.5 rounded-lg font-medium transition-colors"
+            style={{ color: "var(--accent-primary)", background: "var(--bg-elevated)" }}
+          >
+            Retry
+          </button>
         </div>
       ) : !content ? (
         <EmptyState

--- a/src/components/settings/AccountTab.tsx
+++ b/src/components/settings/AccountTab.tsx
@@ -79,7 +79,7 @@ export function AccountTab() {
             type="text"
             value={displayName}
             onChange={(e) => setDisplayName(e.target.value)}
-            className="w-full rounded-lg px-4 py-3 focus:outline-none transition-colors"
+            className="w-full rounded-lg px-4 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] transition-colors"
             style={{
               background: "var(--bg-input)",
               color: "var(--text-primary)",
@@ -98,7 +98,7 @@ export function AccountTab() {
           <select
             value={timezone}
             onChange={(e) => setTimezone(e.target.value)}
-            className="w-full rounded-lg px-4 py-3 focus:outline-none transition-colors"
+            className="w-full rounded-lg px-4 py-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)] transition-colors"
             style={{
               background: "var(--bg-input)",
               color: "var(--text-primary)",

--- a/src/components/settings/DangerZoneTab.tsx
+++ b/src/components/settings/DangerZoneTab.tsx
@@ -14,6 +14,10 @@ export function DangerZoneTab() {
   const [wipeError, setWipeError] = useState<string | null>(null);
   const [wipeSuccess, setWipeSuccess] = useState(false);
 
+  // Tolerate casing/whitespace so a correct-but-untrimmed phrase isn't a dead
+  // button. The server independently requires {confirm:"WIPE"}, so this is safe.
+  const confirmMatches = confirmText.trim().toLowerCase() === CONFIRM_PHRASE;
+
   const handleExport = async () => {
     setIsExporting(true);
     setExportError(null);
@@ -191,7 +195,7 @@ export function DangerZoneTab() {
                 type="text"
                 value={confirmText}
                 onChange={(e) => setConfirmText(e.target.value)}
-                className="w-full rounded-lg px-4 py-2 text-sm focus:outline-none"
+                className="w-full rounded-lg px-4 py-2 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-negative)]"
                 style={{
                   background: "var(--bg-input)",
                   color: "var(--text-primary)",
@@ -200,6 +204,11 @@ export function DangerZoneTab() {
                 placeholder={CONFIRM_PHRASE}
                 autoFocus
               />
+              {confirmText.trim() && !confirmMatches && (
+                <p className="mt-1.5 text-xs" style={{ color: "var(--text-muted)" }}>
+                  Doesn&apos;t match yet — type &ldquo;{CONFIRM_PHRASE}&rdquo; (case and spacing are ignored).
+                </p>
+              )}
             </div>
             {wipeError && (
               <p className="text-xs" style={{ color: "var(--accent-negative)" }}>
@@ -224,7 +233,7 @@ export function DangerZoneTab() {
               </button>
               <button
                 onClick={handleWipe}
-                disabled={confirmText !== CONFIRM_PHRASE || isWiping}
+                disabled={!confirmMatches || isWiping}
                 className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-opacity disabled:opacity-30"
                 style={{
                   background: "var(--accent-negative)",

--- a/src/components/settings/PreferencesTab.tsx
+++ b/src/components/settings/PreferencesTab.tsx
@@ -33,7 +33,7 @@ export function PreferencesTab() {
             <button
               key={id}
               onClick={() => setTheme(id)}
-              className="flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors"
+              className="flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]"
               style={{
                 background: theme === id ? "var(--accent-primary)" : "var(--bg-elevated)",
                 color: theme === id ? "var(--bg-base)" : "var(--text-secondary)",

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -39,7 +39,10 @@ export function Settings() {
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
-                className="flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium whitespace-nowrap transition-colors"
+                aria-label={tab.label}
+                aria-pressed={isActive}
+                title={tab.label}
+                className="flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-primary)]"
                 style={{
                   background: isActive ? "var(--bg-elevated)" : "transparent",
                   color: isActive

--- a/src/components/shared/DateNavigation.tsx
+++ b/src/components/shared/DateNavigation.tsx
@@ -26,6 +26,7 @@ export function DateNavigation({ date, onDateChange, mode = "day" }: DateNavigat
     <div className="flex items-center gap-2">
       <button
         onClick={handlePrev}
+        aria-label={mode === "week" ? "Previous week" : "Previous day"}
         className="p-1.5 rounded-lg transition-colors hover:opacity-80"
         style={{ color: "var(--text-secondary)" }}
       >
@@ -39,6 +40,7 @@ export function DateNavigation({ date, onDateChange, mode = "day" }: DateNavigat
       </span>
       <button
         onClick={handleNext}
+        aria-label={mode === "week" ? "Next week" : "Next day"}
         className="p-1.5 rounded-lg transition-colors hover:opacity-80"
         style={{ color: "var(--text-secondary)" }}
       >

--- a/src/components/shared/DateNavigation.tsx
+++ b/src/components/shared/DateNavigation.tsx
@@ -7,14 +7,23 @@ interface DateNavigationProps {
   date: string;
   onDateChange: (date: string) => void;
   mode?: "day" | "week";
+  /** Latest navigable date (YYYY-MM-DD). Disables forward nav past it. */
+  maxDate?: string;
 }
 
-export function DateNavigation({ date, onDateChange, mode = "day" }: DateNavigationProps) {
+export function DateNavigation({ date, onDateChange, mode = "day", maxDate }: DateNavigationProps) {
+  const nextDisabled = maxDate
+    ? mode === "week"
+      ? startOfWeek(date) >= startOfWeek(maxDate)
+      : date >= maxDate
+    : false;
+
   const handlePrev = () => {
     onDateChange(addDays(date, mode === "week" ? -7 : -1));
   };
 
   const handleNext = () => {
+    if (nextDisabled) return;
     onDateChange(addDays(date, mode === "week" ? 7 : 1));
   };
 
@@ -40,8 +49,9 @@ export function DateNavigation({ date, onDateChange, mode = "day" }: DateNavigat
       </span>
       <button
         onClick={handleNext}
+        disabled={nextDisabled}
         aria-label={mode === "week" ? "Next week" : "Next day"}
-        className="p-1.5 rounded-lg transition-colors hover:opacity-80"
+        className="p-1.5 rounded-lg transition-colors hover:opacity-80 disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:opacity-30"
         style={{ color: "var(--text-secondary)" }}
       >
         <ChevronRight className="w-4 h-4" />

--- a/src/components/shared/Toast.tsx
+++ b/src/components/shared/Toast.tsx
@@ -58,7 +58,10 @@ export function ToastContainer() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-20 right-4 z-[60] flex flex-col gap-2">
+    <div
+      className="fixed right-4 z-[80] flex flex-col gap-2"
+      style={{ bottom: "calc(60px + env(safe-area-inset-bottom, 0px) + 1rem)" }}
+    >
       {toasts.map((toast) => (
         <ToastItem key={toast.id} {...toast} onRemove={removeToast} />
       ))}

--- a/src/components/spaces/SpaceFormModal.tsx
+++ b/src/components/spaces/SpaceFormModal.tsx
@@ -14,8 +14,8 @@ interface SpaceFormModalProps {
 export function SpaceFormModal({ space, onClose, onSave }: SpaceFormModalProps) {
   const [name, setName] = useState(space?.name || "");
   const [description, setDescription] = useState(space?.description || "");
-  const [status] = useState<"active" | "paused" | "completed">(space?.status || "active");
-  const [deadline] = useState(space?.deadline || "");
+  const [status, setStatus] = useState<"active" | "paused" | "completed">(space?.status || "active");
+  const [deadline, setDeadline] = useState(space?.deadline || "");
   const [isSaving, setIsSaving] = useState(false);
   const { addToast } = useToast();
 
@@ -128,6 +128,36 @@ export function SpaceFormModal({ space, onClose, onSave }: SpaceFormModalProps) 
               rows={3}
               placeholder="What is this space about?"
             />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium mb-1" style={{ color: "var(--text-secondary)" }}>
+                Status
+              </label>
+              <select
+                value={status}
+                onChange={(e) => setStatus(e.target.value as "active" | "paused" | "completed")}
+                className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
+                style={{ background: "var(--bg-base)", color: "var(--text-primary)", border: "1px solid var(--border-default)" }}
+              >
+                <option value="active">Active</option>
+                <option value="paused">Paused</option>
+                <option value="completed">Completed</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1" style={{ color: "var(--text-secondary)" }}>
+                Deadline
+              </label>
+              <input
+                type="date"
+                value={deadline}
+                onChange={(e) => setDeadline(e.target.value)}
+                className="w-full rounded-lg px-3 py-2 text-sm focus:outline-none"
+                style={{ background: "var(--bg-base)", color: "var(--text-primary)", border: "1px solid var(--border-default)" }}
+              />
+            </div>
           </div>
 
           <div className="flex justify-end gap-2 pt-2">

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -115,9 +115,12 @@ export function TaskFormModal({ task, spaces, defaultDate, defaultSpaceId, onClo
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-2" style={{ color: "var(--text-secondary)" }}>
+          <label className="block text-sm font-medium mb-1" style={{ color: "var(--text-secondary)" }}>
             Priority
           </label>
+          <p className="text-xs mb-2" style={{ color: "var(--text-muted)" }}>
+            A/B/C is importance; the number is sub-rank within it (1 = highest).
+          </p>
           <div className="grid grid-cols-3 gap-1">
             {["A", "B", "C"].map((letter) => (
               <div key={letter}>

--- a/src/components/tasks/TaskFormModal.tsx
+++ b/src/components/tasks/TaskFormModal.tsx
@@ -12,19 +12,20 @@ interface TaskFormModalProps {
   spaces?: Space[];
   defaultDate?: string;
   defaultSpaceId?: string;
+  defaultGoalId?: string;
   onClose: () => void;
   onSave: (task: Task) => void;
 }
 
 const PRIORITY_LABELS: Record<string, string> = { A: "Must Do", B: "Should Do", C: "Nice to Do" };
 
-export function TaskFormModal({ task, spaces, defaultDate, defaultSpaceId, onClose, onSave }: TaskFormModalProps) {
+export function TaskFormModal({ task, spaces, defaultDate, defaultSpaceId, defaultGoalId, onClose, onSave }: TaskFormModalProps) {
   const [title, setTitle] = useState(task?.title || "");
   const [notes, setNotes] = useState(task?.notes || "");
   const [priority, setPriority] = useState(task?.priority || "B1");
   const [taskDate, setTaskDate] = useState(task?.task_date || defaultDate || getToday());
   const [spaceId, setSpaceId] = useState(task?.space_id || defaultSpaceId || "");
-  const [goalId, setGoalId] = useState(task?.goal_id || "");
+  const [goalId, setGoalId] = useState(task?.goal_id || defaultGoalId || "");
   const [recurrenceType, setRecurrenceType] = useState(task?.recurrence?.type || "");
   const [isSaving, setIsSaving] = useState(false);
   const { addToast } = useToast();

--- a/src/components/tasks/TaskItem.tsx
+++ b/src/components/tasks/TaskItem.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil, Trash2, ChevronDown, ChevronRight, RotateCcw, GripVertical, Sparkles } from "lucide-react";
+import { Pencil, Trash2, ChevronDown, ChevronRight, RotateCcw, GripVertical, Sparkles, Repeat } from "lucide-react";
 import { Task } from "@/types/database";
 
 interface TaskItemProps {
@@ -81,6 +81,9 @@ export function TaskItem({ task, onToggle, onEdit, onDelete, onBreakdown, isDrag
           </span>
           {task.rolled_from && (
             <span title="Rolled over"><RotateCcw className="w-3 h-3 flex-shrink-0" style={{ color: "var(--text-muted)" }} /></span>
+          )}
+          {task.recurrence && (
+            <span title={`Repeats ${task.recurrence.type}`}><Repeat className="w-3 h-3 flex-shrink-0" style={{ color: "var(--text-muted)" }} /></span>
           )}
         </div>
 

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Plus, CheckSquare } from "lucide-react";
 import { TaskListSkeleton } from "@/components/shared/Skeleton";
 import { Task, Space } from "@/types/database";
@@ -8,6 +8,7 @@ import { DateNavigation } from "@/components/shared/DateNavigation";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { TaskItem } from "./TaskItem";
 import { TaskFormModal } from "./TaskFormModal";
+import { TaskRolloverBanner } from "./TaskRolloverBanner";
 import { getToday } from "@/lib/dates";
 import { useToast } from "@/lib/toast-context";
 
@@ -124,28 +125,44 @@ export function TaskList() {
   const [isLoading, setIsLoading] = useState(true);
   const [showForm, setShowForm] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);
+  const [rolloverCount, setRolloverCount] = useState(0);
+  const [rolloverDismissed, setRolloverDismissed] = useState(false);
+
+  const isToday = date === getToday();
+
+  const loadTasks = useCallback(async (signal?: AbortSignal) => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(`/api/tasks?date=${date}`, signal ? { signal } : undefined);
+      if (response.ok) setTasks(await response.json());
+    } catch (error) {
+      if (signal?.aborted) return;
+      console.error("Failed to load tasks:", error);
+    } finally {
+      if (!signal?.aborted) setIsLoading(false);
+    }
+  }, [date]);
 
   useEffect(() => {
     // Abort on date change/unmount so a slow response can't render a stale day.
     const controller = new AbortController();
-    const loadTasks = async () => {
-      setIsLoading(true);
-      try {
-        const response = await fetch(`/api/tasks?date=${date}`, { signal: controller.signal });
-        if (response.ok) {
-          const data = await response.json();
-          setTasks(data);
-        }
-      } catch (error) {
-        if (controller.signal.aborted) return;
-        console.error("Failed to load tasks:", error);
-      } finally {
-        if (!controller.signal.aborted) setIsLoading(false);
-      }
-    };
-    loadTasks();
+    loadTasks(controller.signal);
     return () => controller.abort();
-  }, [date]);
+  }, [loadTasks]);
+
+  // Surface incomplete past-dated tasks so the user can roll them to today.
+  useEffect(() => {
+    if (!isToday) {
+      setRolloverCount(0);
+      return;
+    }
+    const controller = new AbortController();
+    fetch("/api/tasks/rollover/check", { signal: controller.signal })
+      .then((r) => (r.ok ? r.json() : { count: 0 }))
+      .then((d) => setRolloverCount(d.count ?? 0))
+      .catch(() => {});
+    return () => controller.abort();
+  }, [isToday]);
 
   useEffect(() => {
     fetch("/api/spaces")
@@ -210,6 +227,21 @@ export function TaskList() {
     setEditingTask(null);
   };
 
+  const handleRollover = async () => {
+    try {
+      const response = await fetch("/api/tasks/rollover", { method: "POST" });
+      if (response.ok) {
+        await loadTasks();
+        setRolloverCount(0);
+        addToast("Past tasks rolled over to today");
+      } else {
+        addToast("Failed to roll over tasks");
+      }
+    } catch {
+      addToast("Failed to roll over tasks");
+    }
+  };
+
   const { addToast } = useToast();
   const drag = useDragReorder(tasks, setTasks, addToast);
   const priorityGroups = groupByPriority(tasks);
@@ -238,6 +270,14 @@ export function TaskList() {
           </button>
         </div>
       </div>
+
+      {isToday && rolloverCount > 0 && !rolloverDismissed && (
+        <TaskRolloverBanner
+          count={rolloverCount}
+          onRollover={handleRollover}
+          onDismiss={() => setRolloverDismissed(true)}
+        />
+      )}
 
       {isLoading ? (
         <TaskListSkeleton />

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -28,8 +28,18 @@ function useDragReorder(
 
   const handleDragOver = (taskId: string) => (e: React.DragEvent) => {
     e.preventDefault();
+    if (taskId === dragTaskId) return;
+    // Reordering only works within a priority group, so don't show a drop
+    // indicator (or a "move" cursor) when hovering a different group.
+    const src = tasks.find((t) => t.id === dragTaskId);
+    const tgt = tasks.find((t) => t.id === taskId);
+    if (src && tgt && src.priority[0] !== tgt.priority[0]) {
+      e.dataTransfer.dropEffect = "none";
+      setDragOverTaskId(null);
+      return;
+    }
     e.dataTransfer.dropEffect = "move";
-    if (taskId !== dragTaskId) setDragOverTaskId(taskId);
+    setDragOverTaskId(taskId);
   };
 
   const handleDragLeave = () => {

--- a/src/components/tasks/TaskList.tsx
+++ b/src/components/tasks/TaskList.tsx
@@ -198,6 +198,7 @@ export function TaskList() {
   };
 
   const handleDelete = async (task: Task) => {
+    if (!confirm(`Delete "${task.title}"? This cannot be undone.`)) return;
     // Optimistic removal
     setTasks((prev) => prev.filter((t) => t.id !== task.id));
     try {

--- a/src/components/workouts/WorkoutDashboard.tsx
+++ b/src/components/workouts/WorkoutDashboard.tsx
@@ -60,6 +60,7 @@ export function WorkoutDashboard() {
   }, [isLoading, templates]);
 
   const handleDeleteLog = async (log: WorkoutLog) => {
+    if (!confirm(`Delete the "${log.name}" workout? This removes its logged exercises and cannot be undone.`)) return;
     try {
       const response = await fetch(`/api/workouts/logs/${log.id}`, { method: "DELETE" });
       if (response.ok) {

--- a/src/components/workouts/WorkoutDashboard.tsx
+++ b/src/components/workouts/WorkoutDashboard.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { Plus, Dumbbell, Play, FileText } from "lucide-react";
 import { CardSkeleton } from "@/components/shared/Skeleton";
 import { WorkoutTemplate, WorkoutExercise, WorkoutLog, WorkoutLogExercise } from "@/types/database";
 import { EmptyState } from "@/components/shared/EmptyState";
 import { useToast } from "@/lib/toast-context";
 import { WorkoutLogCard } from "./WorkoutLogCard";
-import { WorkoutLogger } from "./WorkoutLogger";
+import { WorkoutLogger, loadWorkoutDraft } from "./WorkoutLogger";
 import { TemplateFormModal } from "./TemplateFormModal";
 import { WorkoutStats } from "./WorkoutStats";
 
@@ -44,6 +44,21 @@ export function WorkoutDashboard() {
     loadData();
   }, [loadData]);
 
+  // Re-open an in-progress workout that survived a refresh / PWA kill.
+  const restoredDraftRef = useRef(false);
+  useEffect(() => {
+    if (isLoading || restoredDraftRef.current) return;
+    restoredDraftRef.current = true;
+    const draft = loadWorkoutDraft();
+    if (!draft) return;
+    if (draft.templateId === null) {
+      setActiveWorkout("quick");
+    } else {
+      const tpl = templates.find((t) => t.id === draft.templateId);
+      if (tpl) setActiveWorkout(tpl);
+    }
+  }, [isLoading, templates]);
+
   const handleDeleteLog = async (log: WorkoutLog) => {
     try {
       const response = await fetch(`/api/workouts/logs/${log.id}`, { method: "DELETE" });
@@ -70,20 +85,24 @@ export function WorkoutDashboard() {
   if (activeWorkout) {
     const template = activeWorkout === "quick" ? undefined : activeWorkout;
     return (
-      <div className="max-w-2xl mx-auto p-4 md:p-6">
-        <WorkoutLogger
-          template={template}
-          onSave={() => { setActiveWorkout(null); loadData(); }}
-          onCancel={() => setActiveWorkout(null)}
-        />
+      <div className="flex-1 overflow-y-auto pt-[env(safe-area-inset-top,0px)] md:pt-0">
+        <div className="max-w-2xl mx-auto p-4 md:p-6">
+          <WorkoutLogger
+            template={template}
+            onSave={() => { setActiveWorkout(null); loadData(); }}
+            onCancel={() => setActiveWorkout(null)}
+          />
+        </div>
       </div>
     );
   }
 
   if (isLoading) {
     return (
-      <div className="max-w-2xl mx-auto p-4 md:p-6">
-        <CardSkeleton />
+      <div className="flex-1 overflow-y-auto pt-[env(safe-area-inset-top,0px)] md:pt-0">
+        <div className="max-w-2xl mx-auto p-4 md:p-6">
+          <CardSkeleton />
+        </div>
       </div>
     );
   }

--- a/src/components/workouts/WorkoutLogger.tsx
+++ b/src/components/workouts/WorkoutLogger.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Plus, Save, X } from "lucide-react";
 import { WorkoutTemplate, WorkoutExercise } from "@/types/database";
 import { ExerciseSetInput } from "./ExerciseSetInput";
@@ -14,6 +14,36 @@ interface ExerciseEntry {
   sets: Array<{ reps?: number; weight?: number; duration?: number }>;
 }
 
+// An in-progress workout is mirrored to localStorage so a refresh, PWA kill,
+// or accidental navigation doesn't discard a multi-minute logging session.
+export const WORKOUT_DRAFT_KEY = "cadence:workout-draft";
+
+export interface WorkoutDraft {
+  templateId: string | null; // null = quick workout
+  name: string;
+  exercises: ExerciseEntry[];
+  startTime: number;
+}
+
+export function loadWorkoutDraft(): WorkoutDraft | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(WORKOUT_DRAFT_KEY);
+    return raw ? (JSON.parse(raw) as WorkoutDraft) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearWorkoutDraft() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(WORKOUT_DRAFT_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
 interface WorkoutLoggerProps {
   template?: WorkoutTemplate & { workout_exercises?: WorkoutExercise[] };
   onSave: () => void;
@@ -21,24 +51,54 @@ interface WorkoutLoggerProps {
 }
 
 export function WorkoutLogger({ template, onSave, onCancel }: WorkoutLoggerProps) {
-  const [name, setName] = useState(template?.name || "Quick Workout");
+  // Restore a saved draft only if it belongs to this workout slot (same
+  // template, or both "quick"); otherwise start fresh from the template.
+  const [draft] = useState<WorkoutDraft | null>(() => loadWorkoutDraft());
+  const matchesDraft = !!draft && draft.templateId === (template?.id ?? null);
+
+  const [name, setName] = useState(matchesDraft ? draft!.name : template?.name || "Quick Workout");
   const [exercises, setExercises] = useState<ExerciseEntry[]>(
-    template?.workout_exercises?.map((e, i) => ({
-      exercise_name: e.name,
-      exercise_type: e.exercise_type,
-      sort_order: i,
-      sets: Array.from({ length: e.default_sets || 3 }, () =>
-        e.exercise_type === "timed"
-          ? { duration: e.default_duration || 60 }
-          : { reps: e.default_reps || 10, weight: e.default_weight || 0 }
-      ),
-    })) || []
+    matchesDraft
+      ? draft!.exercises
+      : template?.workout_exercises?.map((e, i) => ({
+          exercise_name: e.name,
+          exercise_type: e.exercise_type,
+          sort_order: i,
+          sets: Array.from({ length: e.default_sets || 3 }, () =>
+            e.exercise_type === "timed"
+              ? { duration: e.default_duration || 60 }
+              : { reps: e.default_reps || 10, weight: e.default_weight || 0 }
+          ),
+        })) || []
   );
-  const [startTime] = useState(Date.now());
+  const [startTime] = useState(matchesDraft ? draft!.startTime : Date.now());
   const [isSaving, setIsSaving] = useState(false);
   const [newExerciseName, setNewExerciseName] = useState("");
   const [newExerciseType, setNewExerciseType] = useState("strength");
   const { addToast } = useToast();
+
+  // Persist the working session as it changes; clear once it has no exercises
+  // so an abandoned empty quick-start doesn't get restored later.
+  useEffect(() => {
+    if (exercises.length === 0) {
+      clearWorkoutDraft();
+      return;
+    }
+    try {
+      window.localStorage.setItem(
+        WORKOUT_DRAFT_KEY,
+        JSON.stringify({ templateId: template?.id ?? null, name, exercises, startTime } satisfies WorkoutDraft)
+      );
+    } catch {
+      /* ignore */
+    }
+  }, [name, exercises, startTime, template?.id]);
+
+  const handleCancel = () => {
+    if (exercises.length > 0 && !confirm("Discard this workout? Your logged sets will be lost.")) return;
+    clearWorkoutDraft();
+    onCancel();
+  };
 
   const addExercise = () => {
     if (!newExerciseName.trim()) return;
@@ -79,6 +139,7 @@ export function WorkoutLogger({ template, onSave, onCancel }: WorkoutLoggerProps
       });
 
       if (response.ok) {
+        clearWorkoutDraft();
         onSave();
       } else {
         addToast("Failed to save workout");
@@ -102,7 +163,7 @@ export function WorkoutLogger({ template, onSave, onCancel }: WorkoutLoggerProps
           style={{ color: "var(--text-primary)" }}
         />
         <div className="flex items-center gap-2">
-          <button onClick={onCancel} className="p-2 rounded-lg" style={{ color: "var(--text-muted)" }}>
+          <button onClick={handleCancel} className="p-2 rounded-lg" style={{ color: "var(--text-muted)" }} aria-label="Cancel workout">
             <X className="w-4 h-4" />
           </button>
           <button

--- a/src/components/workouts/WorkoutLogger.tsx
+++ b/src/components/workouts/WorkoutLogger.tsx
@@ -169,6 +169,7 @@ export function WorkoutLogger({ template, onSave, onCancel }: WorkoutLoggerProps
           <button
             onClick={handleSave}
             disabled={exercises.length === 0 || isSaving}
+            title={exercises.length === 0 ? "Add at least one exercise first" : undefined}
             className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-opacity disabled:opacity-50"
             style={{ background: "var(--accent-primary)", color: "var(--bg-base)" }}
           >
@@ -179,6 +180,11 @@ export function WorkoutLogger({ template, onSave, onCancel }: WorkoutLoggerProps
       </div>
 
       <div className="space-y-3">
+        {exercises.length === 0 && (
+          <p className="text-sm text-center py-2" style={{ color: "var(--text-muted)" }}>
+            Add at least one exercise, then tap Finish to save.
+          </p>
+        )}
         {exercises.map((ex, i) => (
           <ExerciseSetInput
             key={i}

--- a/src/hooks/useFocusTimer.ts
+++ b/src/hooks/useFocusTimer.ts
@@ -61,6 +61,28 @@ export function useFocusTimer() {
     }
   }, []);
 
+  // Reliable completion signal for a backgrounded tab: a system notification
+  // (Web Audio is throttled when hidden and the in-app toast isn't visible),
+  // plus a title flash that restores when the tab is next focused.
+  const notifyCompletion = useCallback((title: string, body: string) => {
+    try {
+      if ("Notification" in window && Notification.permission === "granted") {
+        new Notification(title, { body });
+      }
+    } catch {
+      // ignore notification errors
+    }
+    if (typeof document !== "undefined" && document.hidden) {
+      const original = document.title;
+      document.title = `⏰ ${title}`;
+      const restore = () => {
+        document.title = original;
+        document.removeEventListener("visibilitychange", restore);
+      };
+      document.addEventListener("visibilitychange", restore);
+    }
+  }, []);
+
   const handleExpired = useCallback(async (state: TimerState) => {
     if (!state.isBreak && state.sessionId) {
       try {
@@ -135,6 +157,7 @@ export function useFocusTimer() {
   const completeWork = useCallback(async () => {
     if (!timerState) return;
     playNotification();
+    notifyCompletion("Focus session complete", "Nice work — time for a break.");
 
     if (timerState.sessionId) {
       try {
@@ -166,16 +189,17 @@ export function useFocusTimer() {
     setSecondsLeft(timerState.breakDuration);
     completionHandledRef.current = false;
     setIsRunning(true);
-  }, [timerState, playNotification]);
+  }, [timerState, playNotification, notifyCompletion]);
 
   const completeBreak = useCallback(() => {
     playNotification();
+    notifyCompletion("Break over", "Ready for the next focus session?");
     storeState(null);
     setTimerState(null);
     setSecondsLeft(0);
     setIsRunning(false);
     completionHandledRef.current = false;
-  }, [playNotification]);
+  }, [playNotification, notifyCompletion]);
 
   // Handle timer reaching 0. State writes are deferred via queueMicrotask so they
   // don't fire inside the effect's render phase (React 19 set-state-in-effect rule).
@@ -190,6 +214,16 @@ export function useFocusTimer() {
   }, [secondsLeft, timerState, completeBreak, completeWork]);
 
   const start = async (workMinutes: number, breakMinutes: number, taskId: string | null, taskName: string | null) => {
+    // Ask for notification permission at a natural moment — the user just chose
+    // to start a focus session — so completion can alert a backgrounded tab.
+    try {
+      if ("Notification" in window && Notification.permission === "default") {
+        Notification.requestPermission().catch(() => {});
+      }
+    } catch {
+      // ignore
+    }
+
     // Create session in DB
     let sessionId: string | null = null;
     try {

--- a/src/lib/mcp/prompts/index.ts
+++ b/src/lib/mcp/prompts/index.ts
@@ -381,7 +381,7 @@ export function registerPrompts(server: McpServer) {
   // 1. daily_planning
   server.prompt(
     "daily_planning",
-    "Plan my day based on tasks, habits, and calendar",
+    "Plan my day based on tasks, habits, and goals",
     {},
     async (_args, extra: Extra) => {
       const { userId, scopeError } = getPromptAuth(extra, ["tasks:read", "habits:read", "goals:read"]);
@@ -411,10 +411,12 @@ ${JSON.stringify(goals, null, 2)}
 
 Based on this data, please:
 1. Identify my top 3 priority tasks for today (A-priority or most impactful)
-2. Suggest a time-blocked schedule
+2. Suggest an order to tackle the tasks in, grouped by priority
 3. Highlight any habits I haven't completed yet
 4. Note which tasks align with my active goals
-5. Give me a motivating focus for the day`;
+5. Give me a motivating focus for the day
+
+If the data above is empty, do not invent tasks, habits, or goals — say there is nothing scheduled yet and suggest I add some.`;
 
       return {
         messages: [
@@ -458,7 +460,11 @@ ${JSON.stringify(pendingTasks.slice(0, 10), null, 2)}
 ### Habits
 ${JSON.stringify(habits, null, 2)}
 
-Keep it brief: 3-4 bullet points on what matters most today, then a one-sentence motivational close.`;
+Keep it brief: 3-4 bullet points on what matters most today, then a one-sentence motivational close.
+
+If the data above is empty, do not invent tasks or habits — say there is nothing scheduled yet.
+
+After composing the briefing, save it so it shows on the dashboard: call the \`save_daily_briefing\` tool with \`content\` set to your full briefing text. \`briefing_date\` defaults to today (${today}); only set it to write a different day.`;
 
       return {
         messages: [
@@ -605,7 +611,9 @@ Please:
 2. Diagnose the habits I'm struggling with
 3. Suggest habit stacking opportunities (linking weak habits to strong ones)
 4. Recommend 1-2 habits to add or remove based on the patterns
-5. Give me a concrete improvement plan for the next 2 weeks`;
+5. Give me a concrete improvement plan for the next 2 weeks
+
+If I have no habits yet, do not invent any — say so and suggest a first habit or two worth starting.`;
 
       return {
         messages: [
@@ -762,7 +770,9 @@ Please structure the review with:
 2. **Challenges** — What got in the way?
 3. **Lessons** — What did I learn?
 4. **Next week's intention** — Top 3 focus areas
-5. **Carry-forward tasks** — What needs to move to next week?`;
+5. **Carry-forward tasks** — What needs to move to next week?
+
+After writing the review, save it so it shows on the dashboard: call the \`save_weekly_review\` tool with \`week_start\` exactly equal to "${weekStart}" and \`content\` set to your full review.`;
 
       return {
         messages: [
@@ -848,12 +858,16 @@ ${JSON.stringify(recentWorkouts, null, 2)}
 ## My Saved Templates
 ${JSON.stringify(templates, null, 2)}
 
+Note: the data above only includes exercise names and durations — no sets, reps, weight, or muscle-group labels.
+
 Please:
-1. Identify what muscle groups/types I've recently trained
-2. Recommend what I should focus on today based on recovery needs
+1. Infer the likely muscle groups/types I've recently trained from the exercise names where you can (this is approximate)
+2. Recommend what I should focus on today based on apparent recovery needs
 3. Suggest either a specific saved template or a custom workout plan
-4. Include sets/reps if creating a custom plan
-5. Estimate total time needed`;
+4. Include suggested sets/reps if creating a custom plan
+5. Estimate total time needed
+
+If I have no recent workouts or templates, do not invent history — suggest a sensible starting workout instead.`;
 
       return {
         messages: [
@@ -879,7 +893,15 @@ Please:
 
       if (!goal) {
         return {
-          messages: [{ role: "user" as const, content: { type: "text" as const, text: "Goal not found" } }],
+          messages: [
+            {
+              role: "user" as const,
+              content: {
+                type: "text" as const,
+                text: `ERROR: No goal exists with id "${args.goal_id}". Do not generate a plan — tell the user the goal ID is invalid and suggest they list their goals to find the right one.`,
+              },
+            },
+          ],
         };
       }
 

--- a/src/lib/mcp/resources/briefings.ts
+++ b/src/lib/mcp/resources/briefings.ts
@@ -8,7 +8,7 @@ export function registerBriefingResources(server: McpServer) {
   server.resource(
     "briefing-today",
     "cadence://briefing/today",
-    { description: "Today's AI-generated daily briefing, if one has been generated" },
+    { description: "Today's saved daily briefing, if one exists" },
     async (uri, extra: Extra) => {
       const auth = getAuth(extra);
       if (!auth) return { contents: [] };

--- a/src/lib/mcp/tools/briefings.ts
+++ b/src/lib/mcp/tools/briefings.ts
@@ -11,13 +11,12 @@ import { dateSchema } from "./validators";
 // Query helpers
 // ---------------------------------------------------------------------------
 
-async function getTodayBriefing(userId: string) {
-  const today = getToday();
+async function getBriefingForDate(userId: string, date: string) {
   try {
     const rows = await db
       .select()
       .from(dailyBriefings)
-      .where(and(eq(dailyBriefings.userId, userId), eq(dailyBriefings.briefingDate, today)));
+      .where(and(eq(dailyBriefings.userId, userId), eq(dailyBriefings.briefingDate, date)));
     return { data: rows.length > 0 ? rows[0] : null, error: null };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
@@ -55,20 +54,23 @@ export function registerBriefingTools(server: McpServer) {
   // --- get_daily_briefing (READ) ---
   server.tool(
     "get_daily_briefing",
-    "Get the daily briefing for today",
-    {},
-    async (_args, extra: Extra) => {
+    "Get the daily briefing for a date (defaults to today)",
+    {
+      date: dateSchema.optional().describe("Briefing date in YYYY-MM-DD format (defaults to today)"),
+    },
+    async (args, extra: Extra) => {
       const auth = getAuth(extra);
       if (!auth) return NOT_AUTHENTICATED;
 
       const scopeError = checkScope(auth.scopes, "briefing:read");
       if (scopeError) return errorResult(scopeError);
 
-      const result = await getTodayBriefing(auth.userId);
+      const date = args.date ?? getToday();
+      const result = await getBriefingForDate(auth.userId, date);
       if (result.error) return errorResult(`Error: ${result.error}`);
 
       if (!result.data) {
-        return textResult({ message: "No briefing saved for today." });
+        return textResult({ message: `No briefing saved for ${date}.` });
       }
 
       return textResult(result.data);

--- a/src/lib/mcp/tools/focus.ts
+++ b/src/lib/mcp/tools/focus.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db/client";
 import { focusSessions } from "@/lib/db/schema";
 import { eq, and, gte, lte, desc } from "drizzle-orm";
 import { getAuth, checkScope, textResult, errorResult, conflictResult, NOT_AUTHENTICATED, Extra } from "./helpers";
-import { dateSchema } from "./validators";
+import { dateSchema, uuidSchema } from "./validators";
 import { updateWithVersion } from "@/lib/db/optimistic";
 
 // ---------------------------------------------------------------------------
@@ -189,7 +189,7 @@ export function registerFocusTools(server: McpServer) {
     "Start a new focus/Pomodoro session",
     {
       duration_minutes: z.number().int().min(1).max(480).describe("Focus session duration in minutes (1-480, e.g. 25)"),
-      task_id: z.string().optional().describe("Task ID to associate this session with"),
+      task_id: uuidSchema.optional().describe("Task ID to associate this session with (from list_tasks)"),
       break_minutes: z.number().int().min(0).max(120).optional().describe("Break duration in minutes (0-120, default: 5)"),
     },
     async (args, extra: Extra) => {
@@ -211,7 +211,7 @@ export function registerFocusTools(server: McpServer) {
     "complete_focus_session",
     "Mark a focus session as complete. Pass expected_updated_at to opt into concurrency-safe writes.",
     {
-      session_id: z.string().describe("Focus session ID to complete"),
+      session_id: uuidSchema.describe("Focus session ID to complete (from get_focus_sessions)"),
       expected_updated_at: z
         .string()
         .datetime()
@@ -251,7 +251,7 @@ export function registerFocusTools(server: McpServer) {
     "pause_focus_session",
     "Pause an in-progress focus session (sets status to 'paused'). Resume it later with resume_focus_session. Pass expected_updated_at to opt into concurrency-safe writes.",
     {
-      session_id: z.string().describe("Focus session ID to pause"),
+      session_id: uuidSchema.describe("Focus session ID to pause (from get_focus_sessions)"),
       expected_updated_at: z
         .string()
         .datetime()
@@ -291,7 +291,7 @@ export function registerFocusTools(server: McpServer) {
     "resume_focus_session",
     "Resume a paused focus session (sets status back to 'active'). Pass expected_updated_at to opt into concurrency-safe writes.",
     {
-      session_id: z.string().describe("Focus session ID to resume"),
+      session_id: uuidSchema.describe("Focus session ID to resume (from get_focus_sessions)"),
       expected_updated_at: z
         .string()
         .datetime()

--- a/src/lib/mcp/tools/goals.ts
+++ b/src/lib/mcp/tools/goals.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db/client";
 import { goals } from "@/lib/db/schema";
 import { eq, and, desc } from "drizzle-orm";
 import { getAuth, checkScope, textResult, errorResult, conflictResult, NOT_AUTHENTICATED, Extra } from "./helpers";
-import { dateSchema, goalCategorySchema, goalStatusSchema } from "./validators";
+import { dateSchema, goalCategorySchema, goalStatusSchema, uuidSchema } from "./validators";
 import { logGoalProgress } from "@/lib/mcp/queries/goals";
 import { updateWithVersion } from "@/lib/db/optimistic";
 
@@ -168,7 +168,7 @@ export function registerGoalTools(server: McpServer) {
     "update_goal",
     "Update an existing goal's details or status. Pass expected_updated_at to opt into concurrency-safe writes.",
     {
-      goal_id: z.string().describe("Goal ID"),
+      goal_id: uuidSchema.describe("Goal ID (from list_goals)"),
       expected_updated_at: z
         .string()
         .datetime()
@@ -213,7 +213,7 @@ export function registerGoalTools(server: McpServer) {
     "log_goal_progress",
     "Update the progress percentage for a goal",
     {
-      goal_id: z.string().describe("Goal ID"),
+      goal_id: uuidSchema.describe("Goal ID (from list_goals)"),
       progress: z.number().int().min(0).max(100).describe("Progress percentage (0-100)"),
     },
     async (args, extra: Extra) => {
@@ -235,7 +235,7 @@ export function registerGoalTools(server: McpServer) {
     "delete_goal",
     "Delete a goal permanently, including its progress logs. To keep the record, set its status to 'abandoned' via update_goal instead.",
     {
-      goal_id: z.string().describe("Goal ID to delete"),
+      goal_id: uuidSchema.describe("Goal ID to delete (from list_goals)"),
     },
     async (args, extra: Extra) => {
       const auth = getAuth(extra);

--- a/src/lib/mcp/tools/habits.ts
+++ b/src/lib/mcp/tools/habits.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db/client";
 import { habits, habitLogs } from "@/lib/db/schema";
 import { eq, and, asc } from "drizzle-orm";
 import { getAuth, checkScope, textResult, errorResult, conflictResult, NOT_AUTHENTICATED, Extra } from "./helpers";
-import { dateSchema, habitFrequencySchema } from "./validators";
+import { dateSchema, habitFrequencySchema, uuidSchema } from "./validators";
 import { getHabitStats } from "@/lib/mcp/queries/habits";
 import { updateWithVersion } from "@/lib/db/optimistic";
 
@@ -177,7 +177,7 @@ export function registerHabitTools(server: McpServer) {
     "get_habit_stats",
     "Get completion statistics for a specific habit",
     {
-      habit_id: z.string().describe("Habit ID"),
+      habit_id: uuidSchema.describe("Habit ID (from list_habits)"),
       days: z.number().optional().describe("Number of days to analyze (default: 30)"),
     },
     async (args, extra: Extra) => {
@@ -205,7 +205,7 @@ export function registerHabitTools(server: McpServer) {
       target_days: z
         .array(z.number().int().min(1).max(7))
         .optional()
-        .describe("ISO days of week to target (1=Monday, 7=Sunday). Defaults to all 7 days."),
+        .describe("ISO days of week the habit is expected (1=Monday, 7=Sunday). Defaults to all 7 days. Completion stats are scored against these days regardless of frequency, so for a weekly habit list the specific day(s) it should be done."),
       color: z.string().optional().describe("Color hex code for display"),
     },
     async (args, extra: Extra) => {
@@ -227,7 +227,7 @@ export function registerHabitTools(server: McpServer) {
     "toggle_habit",
     "Toggle habit completion for a given date (defaults to today)",
     {
-      habit_id: z.string().describe("Habit ID"),
+      habit_id: uuidSchema.describe("Habit ID (from list_habits)"),
       date: dateSchema.optional().describe("Date in YYYY-MM-DD format (defaults to today)"),
     },
     async (args, extra: Extra) => {
@@ -249,7 +249,7 @@ export function registerHabitTools(server: McpServer) {
     "update_habit",
     "Update a habit's details, or archive/unarchive it via the 'archived' flag. Pass expected_updated_at to opt into concurrency-safe writes.",
     {
-      habit_id: z.string().describe("Habit ID"),
+      habit_id: uuidSchema.describe("Habit ID (from list_habits)"),
       expected_updated_at: z
         .string()
         .datetime()
@@ -261,7 +261,7 @@ export function registerHabitTools(server: McpServer) {
       target_days: z
         .array(z.number().int().min(1).max(7))
         .optional()
-        .describe("ISO days of week to target (1=Monday, 7=Sunday)"),
+        .describe("ISO days of week the habit is expected (1=Monday, 7=Sunday). Completion stats are scored against these days regardless of frequency."),
       color: z.string().optional().describe("New color hex code for display"),
       archived: z.boolean().optional().describe("Set true to archive (hide) the habit, false to restore it"),
     },
@@ -299,7 +299,7 @@ export function registerHabitTools(server: McpServer) {
     "delete_habit",
     "Delete a habit permanently, including all of its completion logs. To keep history, archive it with update_habit instead.",
     {
-      habit_id: z.string().describe("Habit ID to delete"),
+      habit_id: uuidSchema.describe("Habit ID to delete (from list_habits)"),
     },
     async (args, extra: Extra) => {
       const auth = getAuth(extra);

--- a/src/lib/mcp/tools/insights.ts
+++ b/src/lib/mcp/tools/insights.ts
@@ -16,13 +16,12 @@ const insightsPayloadSchema = z.union([
 // Query helpers
 // ---------------------------------------------------------------------------
 
-async function getTodayInsights(userId: string) {
-  const today = getToday();
+async function getInsightsForDate(userId: string, date: string) {
   try {
     const rows = await db
       .select()
       .from(insightCache)
-      .where(and(eq(insightCache.userId, userId), eq(insightCache.cacheDate, today)));
+      .where(and(eq(insightCache.userId, userId), eq(insightCache.cacheDate, date)));
     return { data: rows.length > 0 ? rows[0] : null, error: null };
   } catch (err) {
     return { data: null, error: err instanceof Error ? err.message : "Unknown error" };
@@ -59,20 +58,23 @@ export function registerInsightTools(server: McpServer) {
   // --- get_insights (READ) ---
   server.tool(
     "get_insights",
-    "Get today's cached insights",
-    {},
-    async (_args, extra: Extra) => {
+    "Get cached insights for a date (defaults to today)",
+    {
+      date: dateSchema.optional().describe("Cache date in YYYY-MM-DD format (defaults to today)"),
+    },
+    async (args, extra: Extra) => {
       const auth = getAuth(extra);
       if (!auth) return NOT_AUTHENTICATED;
 
       const scopeError = checkScope(auth.scopes, "insights:read");
       if (scopeError) return errorResult(scopeError);
 
-      const result = await getTodayInsights(auth.userId);
+      const date = args.date ?? getToday();
+      const result = await getInsightsForDate(auth.userId, date);
       if (result.error) return errorResult(`Error: ${result.error}`);
 
       if (!result.data) {
-        return textResult({ message: "No insights saved for today." });
+        return textResult({ message: `No insights saved for ${date}.` });
       }
 
       return textResult(result.data);

--- a/src/lib/mcp/tools/journal.ts
+++ b/src/lib/mcp/tools/journal.ts
@@ -192,7 +192,7 @@ export function registerJournalTools(server: McpServer) {
   // --- create_journal_entry (WRITE) ---
   server.tool(
     "create_journal_entry",
-    "Create or update a journal entry for a given date (defaults to today). Omitting mood keeps the entry's existing mood. When updating an existing entry, pass expected_updated_at to opt into concurrency-safe writes.",
+    "Create or update a journal entry for a given date (defaults to today). WARNING: this REPLACES the entire content for that date — it does not append. To add to an existing entry, first read it with get_journal_entries and include the existing text in `content`. Omitting mood keeps the entry's existing mood. When updating an existing entry, pass expected_updated_at to opt into concurrency-safe writes.",
     {
       content: z.string().describe("Journal entry content"),
       entry_date: dateSchema.optional().describe("Date in YYYY-MM-DD format (defaults to today)"),

--- a/src/lib/mcp/tools/tasks.ts
+++ b/src/lib/mcp/tools/tasks.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db/client";
 import { tasks } from "@/lib/db/schema";
 import { eq, and, or, lt, asc } from "drizzle-orm";
 import { getAuth, checkScope, textResult, errorResult, conflictResult, NOT_AUTHENTICATED, Extra } from "./helpers";
-import { dateSchema, prioritySchema, priorityDescription } from "./validators";
+import { dateSchema, prioritySchema, priorityDescription, uuidSchema } from "./validators";
 import { updateWithVersion } from "@/lib/db/optimistic";
 import { maybeSpawnNextOccurrence } from "@/lib/mcp/queries/tasks";
 
@@ -167,7 +167,7 @@ export function registerTaskTools(server: McpServer) {
     "List tasks for a given date (defaults to today). Incomplete tasks from previous days are included when viewing today.",
     {
       date: dateSchema.optional().describe("Date in YYYY-MM-DD format (defaults to today)"),
-      space_id: z.string().optional().describe("Filter by space/project ID"),
+      space_id: uuidSchema.optional().describe("Filter by space/project ID (from list_spaces)"),
     },
     async (args, extra: Extra) => {
       const auth = getAuth(extra);
@@ -192,8 +192,8 @@ export function registerTaskTools(server: McpServer) {
       notes: z.string().optional().describe("Additional notes"),
       priority: prioritySchema.optional().describe(priorityDescription),
       task_date: dateSchema.optional().describe("Date in YYYY-MM-DD format (defaults to today)"),
-      space_id: z.string().optional().describe("Space/project ID to assign to"),
-      goal_id: z.string().optional().describe("Goal ID to link to"),
+      space_id: uuidSchema.optional().describe("Space/project ID to assign to (from list_spaces)"),
+      goal_id: uuidSchema.optional().describe("Goal ID to link to (from list_goals)"),
     },
     async (args, extra: Extra) => {
       const auth = getAuth(extra);
@@ -212,9 +212,9 @@ export function registerTaskTools(server: McpServer) {
   // --- update_task (WRITE) ---
   server.tool(
     "update_task",
-    "Update an existing task. Marking a recurring task done schedules its next occurrence (same as complete_task). Pass expected_updated_at (from the last read of this task) to opt into concurrency-safe writes — the call will fail with a conflict if the task was modified in the meantime.",
+    "Update one or more fields of an existing task. To only mark a task done, prefer complete_task. Marking a recurring task done schedules its next occurrence (same as complete_task). Pass expected_updated_at (from the last read of this task) to opt into concurrency-safe writes — the call will fail with a conflict if the task was modified in the meantime.",
     {
-      task_id: z.string().describe("Task ID"),
+      task_id: uuidSchema.describe("Task ID (from list_tasks)"),
       expected_updated_at: z
         .string()
         .datetime()
@@ -269,9 +269,9 @@ export function registerTaskTools(server: McpServer) {
   // --- complete_task (WRITE) ---
   server.tool(
     "complete_task",
-    "Mark a task as complete. Pass expected_updated_at to opt into concurrency-safe writes.",
+    "Mark a task as complete. Preferred for simply finishing a task; use update_task only when also changing other fields. Pass expected_updated_at to opt into concurrency-safe writes.",
     {
-      task_id: z.string().describe("Task ID to complete"),
+      task_id: uuidSchema.describe("Task ID to complete (from list_tasks)"),
       expected_updated_at: z
         .string()
         .datetime()
@@ -321,7 +321,7 @@ export function registerTaskTools(server: McpServer) {
     "delete_task",
     "Delete a task permanently",
     {
-      task_id: z.string().describe("Task ID to delete"),
+      task_id: uuidSchema.describe("Task ID to delete (from list_tasks)"),
     },
     async (args, extra: Extra) => {
       const auth = getAuth(extra);

--- a/src/lib/mcp/tools/validators.ts
+++ b/src/lib/mcp/tools/validators.ts
@@ -4,6 +4,15 @@ export const dateSchema = z
   .string()
   .regex(/^\d{4}-\d{2}-\d{2}$/, "Must be YYYY-MM-DD format");
 
+// Mirrors Postgres's `uuid` type: any hex in 8-4-4-4-12 shape, without RFC
+// version/variant strictness (which would reject ids Postgres accepts).
+export const uuidSchema = z
+  .string()
+  .regex(
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/,
+    "Must be a valid UUID — copy the id from a list_*/get_* result rather than inventing one"
+  );
+
 export const prioritySchema = z
   .string()
   .regex(/^[A-C][1-9]$/, "Must be A1-C9 (letter A/B/C + digit 1-9)");


### PR DESCRIPTION
Works through the 2026-06-15 multi-agent user-ability review (`docs/usability-review-2026-06-15.md`, 60 verified findings) across all three audiences. All green: production build, 390 tests, lint, typecheck.

## MCP / OpenClaw consumer (13/17)
- **Blocker:** `morning_briefing` now instructs the agent to call `save_daily_briefing` — the read→generate→save loop never closed, so dashboard widgets stayed empty forever.
- `weekly_review` echoes the exact `week_start` key for `save_weekly_review`; `daily_planning` no longer advertises calendar data it never fetches; `create_journal_entry` warns it replaces content; "if data is empty, don't invent" guards; `goal_planning` hard-errors on bad id.
- uuid validation on id params (clean errors vs raw Postgres), ID-source hints, `get_daily_briefing`/`get_insights` date params, target_days docs, provider-neutral resource wording.

## Dashboard (all 8 highs + mediums + most lows)
- **Highs:** task-rollover banner wired, unscrollable active workout, in-progress workout persistence, editable goal status, space status/deadline, calendar error state, icon aria-labels, discoverable/touch-reachable command palette.
- **Mediums:** honest empty/error states, refresh-after-Daily-Start, confirm-before-delete (×4), settings a11y + focus rings, future-date clamping, recurrence badge, focus-completion notifications, goal↔task linking, calendar day-cell a11y.
- **Lows:** typography plugin for briefings, ErrorBoundary escapes, toast z-index, date formatting, habit badge, workout-finish hint, priority caption, cross-priority drag feedback, forgiving wipe confirm, journal mood hint.

## Self-hoster docs
Image-tag corrections (`:v1`/`:1` → `:2`, no-`v`-prefix note), firewall guidance aligned with the bind-based protection, `POSTGRES_PASSWORD` required, install prereqs, stale version dropped, update-command clarifications, `SELF_HOSTED_USER_ID` permanence.

## Deferred (documented in the review doc, not in this PR)
- 4 MCP contract-change items (need an OpenClaw heads-up): `exercises` array, `save_insights` shape, stronger `expected_updated_at` nudge, template→log instantiation.
- Pinch-to-zoom (needs ≥16px input sweep first), mobile theme toggle, full mood-only journal (needs `content` migration), blanket ErrorBoundary coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)